### PR TITLE
Bring 3.9 scenarios side-by-side with 3.7

### DIFF
--- a/scenarios-3.9-pathway.json
+++ b/scenarios-3.9-pathway.json
@@ -1,0 +1,51 @@
+{
+  "title": "OpenShift Cloud-Native Roadshow",
+  "description": "",
+  "courses": [
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "getting-started",
+      "title": "Getting Started with OpenShift"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "microservice-wildfly-swarm",
+      "title": "Enterprise Microservices with WildFly Swarm"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "microservice-spring-boot",
+      "title": "Microservices with Spring Boot"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "microservice-vertx",
+      "title": "Reactive Microservices with Eclipse Vert.x"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "microservice-nodejs",
+      "title": "Web UI with Node.js and AngularJS"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "monitor-health",
+      "title": "Monitoring Application Health"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "manage-config",
+      "title": "Managing Application Configuration"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "continuous-delivery",
+      "title": "Continuous Delivery"
+    },
+    {
+      "pathway_id": "scenarios-3.9",
+      "course_id": "debug-app",
+      "title": "Debugging Applications"
+    }
+  ]
+}

--- a/scenarios-3.9/continuous-delivery/00-intro.md
+++ b/scenarios-3.9/continuous-delivery/00-intro.md
@@ -1,0 +1,19 @@
+In this scenario you will learn about deployment pipelines and you will create a pipeline to 
+automate build and deployment of the Inventory service.
+
+#### Continuous Delivery
+So far you have been building and deploying each service manually to OpenShift. Although 
+it's convenient for local development, it's an error-prone way of delivering software if 
+extended to test and production environments.
+
+Continuous Delivery (CD) refers to a set of practices with the intention of automating 
+various aspects of delivery software. One of these practices is called delivery pipeline 
+which is an automated process to define the steps a change in code or configuration has 
+to go through in order to reach upper environments and eventually to production. 
+
+OpenShift simplifies building CI/CD Pipelines by integrating
+the popular [Jenkins pipelines](https://jenkins.io/doc/book/pipeline/overview/) into
+the platform and enables defining truly complex workflows directly from within OpenShift.
+
+The first step for any deployment pipeline is to store all code and configurations in 
+a source code repository.

--- a/scenarios-3.9/continuous-delivery/01-create-repo.md
+++ b/scenarios-3.9/continuous-delivery/01-create-repo.md
@@ -1,0 +1,26 @@
+There is a Gogs Git Server deployed on your OpenShift cluster which you can use 
+for version control during this scenario. Open Gogs in a new browser tab:
+
+<http://gogs-infra-app-[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com>
+
+Register with the following details:
+* Username: **developer**
+* Email: **developer@me.com**
+* Password: **developer**
+
+Login after registration and then click on the plus icon on the top navigation 
+bar and then on **New Repository**.
+
+![Create New Repository](https://katacoda.com/openshift-roadshow/assets/cd-gogs-plus-icon.png)
+
+Give **inventory-wildfly-swarm** as **Repository Name** and click on **Create Repository** 
+button, leaving the rest with default values.
+
+![Create New Repository](https://katacoda.com/openshift-roadshow/assets/cd-gogs-new-repo.png)
+
+The Git repository is created now. 
+
+Click on the copy-to-clipboard icon to near the 
+HTTP Git url to copy it to the clipboard which you will need in a few minutes.
+
+![Empty Repository](https://katacoda.com/openshift-roadshow/assets/cd-gogs-empty-repo.png)

--- a/scenarios-3.9/continuous-delivery/02-init-repo.md
+++ b/scenarios-3.9/continuous-delivery/02-init-repo.md
@@ -1,0 +1,53 @@
+Now that you have a Git repository for the Inventory service, you should push the 
+source code into this Git repository.
+
+Go the **inventory-wildfly-swarm** folder, initialize it as a Git working copy and add 
+the GitHub repository as the remote repository for your working copy. 
+
+```
+cd inventory-wildfly-swarm
+```{{execute}}
+
+```
+git init
+```{{execute}}
+
+```
+git remote add origin http://gogs-infra-app-[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/developer/inventory-wildfly-swarm.git
+```{{execute}}
+
+Before you commit the source code to the Git repository, configure your name and 
+email so that the commit owner can be seen on the repository. If you want, you can 
+replace the name and the email with your own in the following commands:
+
+```
+git config --global user.name "Developer"
+```{{execute}}
+
+```
+git config --global user.email "developer@me.com"
+```{{execute}}
+
+Commit and push the existing code to the GitHub repository.
+
+```
+git add . --all
+```{{execute}}
+
+```
+git commit -m "initial add"
+```{{execute}}
+
+```
+git push -u origin master
+```{{execute}}
+
+
+Enter your Git repository credentials if you get asked to enter your credentials. 
+* Username: **developer**
+* Password: **developer**
+
+Go to your **inventory-wildfly-swarm** repository web interface and refresh the page. You should 
+see the project files in the repository.
+
+![Inventory Repository](https://katacoda.com/openshift-roadshow/assets/cd-gogs-inventory-repo.png)

--- a/scenarios-3.9/continuous-delivery/03-define-pipeline.md
+++ b/scenarios-3.9/continuous-delivery/03-define-pipeline.md
@@ -1,0 +1,60 @@
+OpenShift has built-in support for CI/CD pipelines by allowing developers to define
+a [Jenkins pipeline](https://jenkins.io/solutions/pipeline/) for execution by a Jenkins
+automation engine, which is automatically provisioned on-demand by OpenShift when needed.
+
+The build can get started, monitored, and managed by OpenShift in
+the same way as any other build types e.g. S2I. Pipeline workflows are defined in
+a Jenkinsfile, either embedded directly in the build configuration, or supplied in
+a Git repository and referenced by the build configuration.
+
+Jenkinsfile is a text file that contains the definition of a Jenkins Pipeline
+and is created using a [scripted or declarative syntax](https://jenkins.io/doc/book/pipeline/syntax/).
+
+Create a file called **Jenkinsfile** in the root the **inventory-wildfly-swarm** by clicking on
+ *Copy to Editor*:
+
+<pre class="file" data-filename="./inventory-wildfly-swarm/Jenkinsfile" data-target="replace">
+pipeline {
+  agent {
+      label 'maven'
+  }
+  stages {
+    stage('Build JAR') {
+      steps {
+        sh "mvn package"
+        stash name:"jar", includes:"target/inventory-1.0-SNAPSHOT-swarm.jar"
+      }
+    }
+    stage('Build Image') {
+      steps {
+        unstash name:"jar"
+        script {
+          openshift.withCluster() {
+            openshift.startBuild("inventory-s2i", "--from-file=target/inventory-1.0-SNAPSHOT-swarm.jar", "--wait")
+          }
+        }
+      }
+    }
+    stage('Deploy') {
+      steps {
+        script {
+          openshift.withCluster() {
+            def dc = openshift.selector("dc", "inventory")
+            dc.rollout().latest()
+            dc.rollout().status()
+          }
+        }
+      }
+    }
+  }
+}
+</pre>
+
+This pipeline has three stages:
+
+* Build JAR: to build and test the jar file using Maven
+* Build Image: to build a container image from the Inventory JAR archive using OpenShift S2I
+* Deploy: to deploy the Inventory container image in the current project
+
+Note that the pipeline definition is fully integrated with OpenShift and you can
+perform operations like image build, image deploy, etc directly from within the **Jenkinsfile**

--- a/scenarios-3.9/continuous-delivery/04-add-pipeline-git.md
+++ b/scenarios-3.9/continuous-delivery/04-add-pipeline-git.md
@@ -1,0 +1,20 @@
+When building deployment pipelines, it's important to treat your [infrastructure and everything else that needs to be configured (including the pipeline definition) as code](https://martinfowler.com/bliki/InfrastructureAsCode.html)
+and store them in a source repository for version control.
+
+Commit and push the **Jenkinsfile** to the Git repository.
+
+```
+git add Jenkinsfile
+```{{execute}}
+
+```
+git commit -m "pipeline added"
+```{{execute}}
+
+```
+git push origin master
+```{{execute}}
+
+Enter your Git credentials if asked. The pipeline definition is 
+ready and now you can create a deployment pipeline using
+this **Jenkinsfile**

--- a/scenarios-3.9/continuous-delivery/05-remove-triggers.md
+++ b/scenarios-3.9/continuous-delivery/05-remove-triggers.md
@@ -1,0 +1,10 @@
+OpenShift automates deployments using [deployment triggers]({{OPENSHIFT_DOCS_BASE}}/dev_guide/deployments/basic_deployment_operations.html#triggers) that react to changes to the container image or configuration. Since you want to control the deployments instead 
+from the pipeline, you should set the Inventory deploy triggers to manual deployment 
+so that building a new Inventory container image wouldn't automatically result in a 
+new deployment. That would allow the pipeline to decide when a deployment should occur.
+
+Set the Inventory deployment triggers to manual:
+
+```
+oc set triggers dc/inventory --manual
+```{{execute}}

--- a/scenarios-3.9/continuous-delivery/06-create-pipeline.md
+++ b/scenarios-3.9/continuous-delivery/06-create-pipeline.md
@@ -1,0 +1,40 @@
+Like mentioned, [OpenShift Pipelines](https://docs.openshift.com/container-platform/3.7/architecture/core_concepts/builds_and_image_streams.html#pipeline-build) enable creating deployment pipelines using the widely popular **Jenkinsfile** format.
+
+First, deploy a Jenkins server using the provided template and container image that 
+comes out-of-the-box with OpenShift:
+
+```
+oc new-app jenkins-ephemeral
+```{{execute}}
+
+After Jenkins is deployed and is running (verify in web console), then create a 
+deployment pipeline by running the following command within the `inventory-widlfly-swarm` folder:
+
+```
+oc new-app . \
+    --name=inventory-pipeline \
+    --strategy=pipeline
+```{{execute}}
+
+The above command creates a new build config of type pipeline which is automatically 
+configured to fetch the **Jenkinsfile** from the Git repository of the current folder 
+(**inventory-wildfly-swarm** Git repository) and execute it on Jenkins.
+
+Click on *Dashboard* to go to the OpenShift Web Console. In the **coolstore** project, 
+click on **Builds &rarr; Pipelines** from the left sidebar.
+
+![OpenShift Pipeline](https://katacoda.com/openshift-roadshow/assets/cd-pipeline-inprogress.png)
+
+Pipeline syntax allows creating complex deployment scenarios with the possibility of defining 
+checkpoint for manual interaction and approval process using 
+[the large set of steps and plugins that Jenkins provide](https://jenkins.io/doc/pipeline/steps/) in 
+order to adapt the pipeline to the process used in your team. You can see a few examples of 
+advanced pipelines in the 
+[OpenShift GitHub Repository](https://github.com/openshift/origin/tree/master/examples/jenkins/pipeline).
+
+In order to update the deployment pipeline, all you need to do is to update the **Jenkinsfile**
+in the **inventory-wildfly-swarm** Git repository. OpenShift pipeline automatically executes the 
+updated pipeline next time it runs.
+
+You can see the pipeline logs by clicking on **View Log** and then logging into Jenkins using 
+your OpenShift credentials and authorizing Jenkins to use your OpenShift credentials.

--- a/scenarios-3.9/continuous-delivery/07-webhooks.md
+++ b/scenarios-3.9/continuous-delivery/07-webhooks.md
@@ -1,0 +1,42 @@
+Manually triggering the deployment pipeline to run is useful but the real goes is to be able 
+to build and deploy every change in code or configuration at least to lower environments 
+(e.g. dev and test) and ideally all the way to production with some manual approvals in-place.
+
+In order to automate triggering the pipeline, you can define a webhook on your Git repository 
+to notify OpenShift on every commit that is made to the Git repository and trigger a pipeline 
+execution.
+
+You can get see the webhook links for your **inventory-pipeline** by viewing pipeline details:
+
+```
+oc describe bc inventory-pipeline
+```{{execute}}
+
+You can also see the webhooks in the OpenShift Web Console by going to **Build &rarr; Pipelines** , 
+click on the pipeline and go to the **Configurations** tab.
+
+Copy the Generic webhook url which you will need in the next steps.
+
+Go to Gogs browser tab and then your **inventory-wildfly-swarm** Git repository, then click on **Settings**:
+
+<http://gogs-infra-app-[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com>
+
+![Repository Settings](https://katacoda.com/openshift-roadshow/assets/cd-gogs-settings-link.png)
+
+On the left menu, click on **Webhooks** and then on **Add Webhook** button and then **Gogs**. 
+
+Create a webhook with the following details:
+
+* **Payload URL**: paste the Generic webhook url you copied from the *inventory-pipeline*
+* **Content type**: application/json
+
+Click on **Add Webhook**. 
+
+![Repository Webhook](https://katacoda.com/openshift-roadshow/assets/cd-gogs-webhook-add.png)
+
+All done. You can click on the newly defined webhook to see the list of **Recent Delivery**. 
+Clicking on the **Test Delivery** button allows you to manually trigger the webhook for 
+testing purposes. Click on it and verify that the **inventory-pipeline** start running 
+immediately.
+
+Well done!

--- a/scenarios-3.9/continuous-delivery/99-outro.md
+++ b/scenarios-3.9/continuous-delivery/99-outro.md
@@ -1,0 +1,1 @@
+Move on to the next scenario, **Debugging Applications** to learn about how to debug microservices.

--- a/scenarios-3.9/continuous-delivery/index.json
+++ b/scenarios-3.9/continuous-delivery/index.json
@@ -1,0 +1,62 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Automating Deployments Using Pipelines",
+    "description": "",
+    "difficulty": "intermediate",
+    "time": "20-30 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Create a Inventory Git Repo",
+                "text": "01-create-repo.md"
+            },
+            {
+                "title": "Push Inventory Code",
+                "text": "02-init-repo.md"
+            },
+            {
+                "title": "Define a Pipeline",
+                "text": "03-define-pipeline.md"
+            },
+            {
+                "title": "Add Pipeline to Git Repo",
+                "text": "04-add-pipeline-git.md"
+            },
+            {
+                "title": "Disable Automatic Deployments",
+                "text": "05-remove-triggers.md"
+            },
+            {
+                "title": "Create an OpenShift Pipeline",
+                "text": "06-create-pipeline.md"
+            },
+            {
+                "title": "Trigger Pipeline on Every Change",
+                "text": "07-webhooks.md"
+            }
+        ],
+        "intro": {
+            "text": "00-intro.md"
+        },
+        "finish": {
+            "text": "99-outro.md"
+        }
+    },
+    "files": [
+      "./Jenkinsfile"
+    ],
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideintro": false,
+        "uisettings": "java",
+        "uieditorpath": "/root/inventory-wildfly-swarm",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/continuous-delivery/run-init.sh
+++ b/scenarios-3.9/continuous-delivery/run-init.sh
@@ -1,0 +1,5 @@
+ssh root@host01 "oc login master:8443 -u system:admin"
+ssh root@host01 "oc import-image jenkins:v3.7 --from='registry.access.redhat.com/openshift3/jenkins-2-rhel7:v3.7' --confirm -n openshift"
+ssh root@host01 "oc export template jenkins-persistent -n openshift -o json | sed 's/jenkins:latest/jenkins:v3.7/g' | oc replace -f - -n openshift"
+ssh root@host01 "oc export template jenkins-ephemeral -n openshift -o json | sed 's/jenkins:latest/jenkins:v3.7/g' | oc replace -f - -n openshift"
+ssh root@host01 "oc login [[HOST_SUBDOMAIN]]-8443-[[KATACODA_HOST]].environments.katacoda.com -u developer -p developer"

--- a/scenarios-3.9/debug-app/00-intro.md
+++ b/scenarios-3.9/debug-app/00-intro.md
@@ -1,0 +1,2 @@
+In this scenario you will debug the coolstore application using Java remote debugging and 
+look into line-by-line code execution as the code runs inside a container on OpenShift.

--- a/scenarios-3.9/debug-app/01-check-logs.md
+++ b/scenarios-3.9/debug-app/01-check-logs.md
@@ -1,0 +1,37 @@
+CoolStore application seem to have a bug that causes the inventory status for one of the 
+products not be displayed in the web interface. 
+
+![Inventory Status Bug](https://katacoda.com/openshift-roadshow/assets/debug-coolstore-bug.png)
+
+This is not an expected behavior! In previous scenarios, you added a circuit breaker to 
+protect the CoolStore application from failures and in case the Inventory API is not 
+available, to skip it and show the products without the inventory status. However, right 
+now the inventory status is available for all products but one which is not how we 
+expect to see the products.
+
+Since the product list is provides by the API Gateway, take a look into the API Gateway 
+logs to see if there are any errors:
+
+```
+oc logs dc/gateway | grep -i error
+```{{execute}}
+
+Oh! Something seems to be wrong with the response the API Gateway has received from the 
+Inventory API for the product id **444436** 
+
+```
+...
+WARNING: Inventory error for 444436: status code 204
+SEVERE: Inventory error for 444436: null
+...
+```
+
+Look into the Inventory pod logs to investigate further and see if you can find more  
+information about this bug:
+
+```
+oc logs dc/inventory | grep ERROR
+```{{execute}}
+
+There doesn't seem to be anything relevant to the **invalid response** error that the 
+API Gateway received either! 

--- a/scenarios-3.9/debug-app/02-check-reponse.md
+++ b/scenarios-3.9/debug-app/02-check-reponse.md
@@ -1,0 +1,15 @@
+Invoke the Inventory API using `curl` for the suspect product id to see what actually 
+happens when API Gateway makes this call:
+
+You can find out the Inventory route url using `oc get route inventory` Replace 
+`INVENTORY-ROUTE-HOST` with the Inventory route url from your project.
+
+```
+curl -v http://INVENTORY-ROUTE-HOST/api/inventory/444436
+```
+
+The response `204 No Content` means no response has come back and that seems to be the 
+reason the inventory status is not displayed 
+on the web interface.
+
+Let's debug the Inventory service to get to the bottom of this!

--- a/scenarios-3.9/debug-app/03-enable-debug.md
+++ b/scenarios-3.9/debug-app/03-enable-debug.md
@@ -1,0 +1,47 @@
+Remote debugging is a useful debugging technique for application development which allows 
+looking into the code that is being executed somewhere else on a different machine and 
+execute the code line-by-line to help investigate bugs and issues. Remote debugging is 
+part of  Java SE standard debugging architecture which you can learn more about it in [Java SE docs](https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/architecture.html).
+
+
+The Java image on OpenShift has built-in support for remote debugging and it can be enabled 
+by setting the `JAVA_DEBUG=true` environment variables on the deployment config for the pod 
+that you want to remotely debug.
+
+```
+oc set env dc/inventory JAVA_DEBUG=true
+```{{execute T2}}
+
+Since you have removed the deployment triggers in the previous scenario, you have to manually 
+trigger a new deployment for the debug environment variable to take effect.
+
+```
+oc rollout latest inventory
+```{{execute T2}}
+
+Wait till the Inventory pod is ready again. Since a pod is not directly accessible to 
+a remote debugger, run the following command to forward the local port 5005 to the Inventory 
+pod on port 5005. The the remote debugger can the connect to a local port and be redirected 
+to the Inventory pod.
+
+First, find the name of the Inventory pod.
+
+```
+oc get pod -l app=inventory
+```{{execute T2}}
+
+An then forward the local port using the following command. Replace the pod name with the 
+Inventory pod name from the previous command.
+
+```
+oc port-forward --server https://master:8443 inventory-n-nnnn 5005 
+```
+
+Notice that the port-forward command keeps running in the terminal in order to 
+forward the specified local port to the pod. 
+
+You are all set now to start debugging using the tools of you choice. 
+
+Remote debugging can be done using the prevalently available
+Java Debugger command line or any modern IDE like JBoss 
+Developer Studio (Eclipse) and IntelliJ IDEA.

--- a/scenarios-3.9/debug-app/04-debug-start.md
+++ b/scenarios-3.9/debug-app/04-debug-start.md
@@ -1,0 +1,30 @@
+The [Java Debugger (JDB)](http://docs.oracle.com/javase/8/docs/technotes/tools/windows/jdb.html) 
+is a simple command-line debugger for Java. The `jdb` command is included by default in 
+Java SE and provides inspection and debugging of a local or remote JVM. Although JDB is not 
+the most convenient way to debug Java code, it's a handy tool since it can be run on any environment 
+that Java SE is available. 
+
+The instructions in this section focuses on using JDB however if you are familiar with JBoss Developer 
+Studio, Eclipse or IntelliJ you can use them for remote debugging.
+
+Go to the **inventory-wildfly-swarm** folder in a new terminal window
+and start JDB by pointing at the folder containing the Java source code for the application under debug:
+
+```
+cd inventory-wildfly-swarm
+```{{execute T3}}
+
+```
+jdb -attach localhost:5005 -sourcepath :src/main/java/
+```{{execute T3}}
+
+Now that you are connected to the JVM running inside the Inventory pod on OpenShift, add 
+a breakpoint to pause the code execution when it reaches the Java method handling the 
+REST API `/api/inventory` Review the `InventoryResource.java` class and note that the 
+`getAvailability()` is the method where you should add the breakpoint.
+
+Add a breakpoint:
+
+```
+stop in com.redhat.cloudnative.inventory.InventoryResource.getAvailability
+```{{execute T3}}

--- a/scenarios-3.9/debug-app/05-debug-pause-breakpoint.md
+++ b/scenarios-3.9/debug-app/05-debug-pause-breakpoint.md
@@ -1,0 +1,10 @@
+In order to pause code execution at the breakpoint, you have to invoke the Inventory 
+REST API once more.
+
+Go back to the first terminal window and re-run the `curl` command to 
+invoke the Inventory REST API.
+
+You can find out the Inventory route url using `oc get routes`. Replace 
+`INVENTORY-ROUTE-HOST` with the Inventory route url from your project.
+
+```curl -v http://INVENTORY-ROUTE-HOST/api/inventory/444436```

--- a/scenarios-3.9/debug-app/06-debug-find-bug.md
+++ b/scenarios-3.9/debug-app/06-debug-find-bug.md
@@ -1,0 +1,63 @@
+The code execution pauses at the `getAvailability()` method. You can verify it 
+using the `list` command to see the source code in the terminal window where 
+you started JDB. The arrow shows which line is to execute next:
+
+Go back to **Terminal 3** and run:
+
+```
+list
+```{{execute T3}}
+
+You'll see an output similar to this.
+
+```
+default task-3[1] list
+21        @GET
+22        @Path("/api/inventory/{itemId}")
+23        @Produces(MediaType.APPLICATION_JSON)
+24        public Inventory getAvailability(@PathParam("itemId") String itemId) {
+25 =>         Inventory inventory = em.find(Inventory.class, itemId);
+26            return inventory;
+27        }
+28    }
+```
+
+Execute one line of code using `next` command so the the inventory object is 
+retrieved from the database.
+
+```
+next
+```{{execute T3}}
+
+Use `locals` command to see the local variables and verify the retrieved inventory 
+object from the database.
+
+```
+locals
+```{{execute T3}}
+
+You'll see an output similar to this.
+
+```
+default task-2[1] locals
+Method arguments:
+itemId = "444436"
+Local variables:
+inventory = null
+```
+
+Oh! Did you notice the problem? 
+
+The `inventory` object which is the object retrieved from the database 
+for the provided product id is `null` and is returned as the REST response! The non-existing 
+product id is not a problem on its own because it simply could mean this product is discontinued 
+and removed from the Inventory database but it's not removed from the product catalog database 
+yet. The bug is however caused because the code returns this `null` value instead of a sensible 
+REST response. If the product id does not exist, a proper JSON response stating a zero inventory 
+should be returned instead of `null`
+
+Exit the debugger.
+
+```
+quit
+```{{execute T3}}

--- a/scenarios-3.9/debug-app/07-fix-code.md
+++ b/scenarios-3.9/debug-app/07-fix-code.md
@@ -1,0 +1,41 @@
+Edit `com/redhat/cloudnative/inventory/InventoryResource.java` add replace the code with 
+the following in order to return a zero inventory for products that don't exist in the inventory 
+database.
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/inventory/InventoryResource.java" data-target="replace">
+package com.redhat.cloudnative.inventory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.wildfly.swarm.health.Health;
+import org.wildfly.swarm.health.HealthStatus;
+import java.util.Date;
+
+@Path("/")
+@ApplicationScoped
+public class InventoryResource {
+    @PersistenceContext(unitName = "InventoryPU")
+    private EntityManager em;
+
+    @GET
+    @Path("/api/inventory/{itemId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Inventory getAvailability(@PathParam("itemId") String itemId) {
+        Inventory inventory = em.find(Inventory.class, itemId);
+
+        if (inventory == null) {
+            inventory = new Inventory();
+            inventory.setItemId(itemId);
+            inventory.setQuantity(0);
+        }
+
+        return inventory;
+    }
+}
+</pre>

--- a/scenarios-3.9/debug-app/08-push-fix.md
+++ b/scenarios-3.9/debug-app/08-push-fix.md
@@ -1,0 +1,33 @@
+Go to the terminal that port forwarding is running in and stop it via 
+pressing **CTRL+C**.
+
+Commit the bug fix to the Git repository.
+
+```
+cd inventory-wildfly-swarm
+```{{execute T2}}
+
+```
+git add src/main/java/com/redhat/cloudnative/inventory/InventoryResource.java
+```{{execute T2}}
+
+```
+git commit -m "inventory returns zero for non-existing product id"
+```{{execute T2}}
+
+```
+git push origin master
+```{{execute T2}}
+
+As soon as you commit the changes to the Git repository, the **inventory-pipeline** gets
+triggered to build and deploy a new Inventory container with the fix. Go to the
+OpenShift Web Console and inside the **coolstore** project. On the sidebar
+menu, Click on **Builds &rarr; Pipelines** to see its progress.
+
+When the pipeline completes successfully, point your browser at the Web route and verify
+that the inventory status is visible for all products. The suspect product should show
+the inventory status as _Not in Stock_.
+
+![Inventory Status Bug Fixed](https://katacoda.com/openshift-roadshow/assets/debug-coolstore-bug-fixed.png)
+
+Well done and congratulations for completing all the scenarios.

--- a/scenarios-3.9/debug-app/index.json
+++ b/scenarios-3.9/debug-app/index.json
@@ -1,0 +1,64 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Debugging Applications",
+    "description": "",
+    "difficulty": "intermediate",
+    "time": "10-15 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Investigate Logs",
+                "text": "01-check-logs.md"
+            },
+            {
+                "title": "Investigate REST Response",
+                "text": "02-check-reponse.md"
+            },
+            {
+                "title": "Enable Debugging",
+                "text": "03-enable-debug.md"
+            },
+            {
+                "title": "Start the JDB Debugger",
+                "text": "04-debug-start.md"
+            },
+            {
+                "title": "Stop at Breakpoint",
+                "text": "05-debug-pause-breakpoint.md"
+            },
+            {
+                "title": "Examine Code Execution",
+                "text": "06-debug-find-bug.md"
+            },
+            {
+                "title": "Fix the Inventory Bug",
+                "text": "07-fix-code.md"
+            },
+            {
+                "title": "Push Fix to Git Repo",
+                "text": "08-push-fix.md"
+            }
+        ],
+        "intro": {
+            "courseData": "run-init.sh",
+            "text": "00-intro.md"
+        }
+    },
+    "files": [
+      "./src/main/java/com/redhat/cloudnative/inventory/InventoryResource.java"
+    ],
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideintro": false,
+        "uisettings": "java",
+        "uieditorpath": "/root/inventory-wildfly-swarm",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/fault-tolerance/00-intro.md
+++ b/scenarios-3.9/fault-tolerance/00-intro.md
@@ -1,0 +1,4 @@
+In this scenario you will learn about how you can build service resilience and fault-tolerant into 
+the applications both at the infrastructure level using OpenShift capabilities as well as 
+at the application level using circuit breakers to prevent cascading failures when 
+downstream dependencies fail.

--- a/scenarios-3.9/fault-tolerance/01-scale-intro.md
+++ b/scenarios-3.9/fault-tolerance/01-scale-intro.md
@@ -1,0 +1,19 @@
+Applications capacity for serving clients is bounded by the amount of computing power 
+allocated to them and although it's possible to increase the computing power per instance, 
+it's far easier to keep the application instances within reasonable sizes and 
+instead add more instances to increase serving capacity. Traditionally, due to 
+the stateful nature of most monolithic applications, increasing capacity had been achieved 
+via scaling up the application server and the underlying virtual or physical machine by adding 
+more cpu and memory (vertical scaling). Cloud-native apps however are stateless and can be 
+easily scaled up by spinning up more application instances and load-balancing requests 
+between those instances (horizontal scaling).
+
+![Scaling Up vs Scaling Out](https://katacoda.com/openshift-roadshow/assets/fault-scale-up-vs-out.png)
+
+In previous scenarios, you learned how to build container images from your application code and 
+deploy them on OpenShift. Container images on OpenShift follow the 
+[immutable server](https://martinfowler.com/bliki/ImmutableServer.html) pattern which guarantees 
+your application instances will always starts from a known well-configured state and makes 
+deploying instances a repeatable practice. Immutable server pattern simplifies scaling out 
+application instances to starting a new instance which is guaranteed to be identical to the 
+existing instances and adding it to the load-balancer.

--- a/scenarios-3.9/fault-tolerance/02-scale-web.md
+++ b/scenarios-3.9/fault-tolerance/02-scale-web.md
@@ -1,0 +1,47 @@
+Now, let's scale up the Web UI to 2 instances. In OpenShift, 
+deployment config is responsible for starting the 
+application pods and ensuring the specified number of instances for each application pod 
+is running. Therefore the number of pods you want to scale to should be defined on the 
+deployment config.
+
+First, get list of deployment configs available in the project.
+
+```
+oc get dc
+```{{execute}}
+
+And then, scale the **web** deployment config to 2 pods:
+
+```
+oc scale dc/web --replicas=2
+```{{execute}}
+
+The `--replicas` option specified the number of Web UI pods that should be running. If you look 
+at the OpenShift Web Console, you can see a new pod is being started for the Web UI and as soon 
+as the health probes pass, it will be automatically added to the load-balancer.
+
+![Scaling Up Pods](https://katacoda.com/openshift-roadshow/assets/fault-scale-up.png)
+
+After the new pod is deployed, you can verify that the new pod is added to the load balancer by checking the details of the 
+Web UI service object:
+
+```
+oc describe svc/web
+```{{execute}}
+
+**Endpoints** shows the IPs of the 2 pods that the load-balancer is sending traffic to.
+
+```
+...
+Endpoints:              10.129.0.146:8080,10.129.0.232:8080
+...
+```
+
+The load-balancer by default, sends the client to the same pod on consequent requests. The 
+[load-balancing strategy](https://docs.openshift.com/container-platform/3.5/architecture/core_concepts/routes.html#load-balancing) 
+can be specified using an annotation on the route object. Run the following 
+to change the load-balancing strategy to round robin: 
+
+```
+oc annotate route/web haproxy.router.openshift.io/balance=roundrobin
+```{{execute}}

--- a/scenarios-3.9/fault-tolerance/03-autoscale-intro.md
+++ b/scenarios-3.9/fault-tolerance/03-autoscale-intro.md
@@ -1,0 +1,30 @@
+Although scaling up and scaling down pods are automated and easy using OpenShift, however it still 
+requires a person or a system to run a command or invoke an API call (to OpenShift REST API. Yup! there
+is a REST API for all OpenShift operations) to scale the applications. That in turn needs to be in response 
+to some sort of increase to the application load and therefore the person or the system needs to be aware of 
+how much load the application is handling at all times to make the scaling decision.
+
+OpenShift automates this aspect of scaling as well via automatically scaling the application pods up 
+and down within a specified min and max boundary based on the container metrics such as cpu and memory 
+consumption. In that case, if there is a surge of users visiting the CoolStore online shop due to 
+holiday season coming up or a good deal on a product, OpenShift would automatically add more pods to 
+handle the increase load on the application and after the load goes, the application is automatically 
+scaled down to free up compute resources.
+
+In order the define auto-scaling for a pod, we should first define how much cpu and memory a pod is 
+allowed to consume which will act as a guideline for OpenShift to know when to scale the pod up or 
+down. Since the deployment config starts the application pods, the application pod resource 
+(cpu and memory) containers should also be defined on the deployment config.
+
+When allocating compute resources to application pods, each container may specify a **request**
+and a **limit** value each for CPU and memory. 
+
+The [*request*](https://docs.openshift.com/container-platform/3.7/dev_guide/compute_resources.html#dev-memory-requests) 
+values define how much resources should be dedicated to an application pod so that it can run. It's 
+the minimum resources needed in other words. 
+
+The [*limit*](https://docs.openshift.com/container-platform/3.7/dev_guide/compute_resources.html#dev-memory-limits) values 
+defines how much resources an application pod is allowed to consume, if there is more resources 
+on the node available than what the pod has request. This is to allow various quality of service 
+tiers with regards to compute resources. You can read more about these quality of service tiers 
+in [OpenShift Documentation](https://docs.openshift.com/container-platform/3.7/dev_guide/compute_resources.html#quality-of-service-tiers).

--- a/scenarios-3.9/fault-tolerance/04-autoscale-define.md
+++ b/scenarios-3.9/fault-tolerance/04-autoscale-define.md
@@ -1,0 +1,44 @@
+Set the following resource constraints on the Web UI pod:
+
+* Memory Request: 256 MB
+* Memory Limit: 512 MB
+* CPU Request: 200 millicore
+* CPU Limit: 300 millicore
+
+CPU is measured in units called millicores while memory is measured in bytes and is specified with [SI suffices](https://docs.openshift.com/container-platform/3.7/dev_guide/compute_resources.html#dev-compute-resources) 
+(E, P, T, G, M, K) or their power-of-two-equivalents (Ei, Pi, Ti, Gi, Mi, Ki).
+
+```
+oc set resources dc/web --limits=cpu=400m,memory=512Mi --requests=cpu=200m,memory=256Mi
+```{{execute}}
+
+The pods get restarted automatically setting the new resource limits in effect. Now you can define an 
+autoscaler to scale the Web UI pods up to 5 instances whenever the CPU consumption passes 40% utilization:
+
+```
+oc autoscale dc/web --min 1 --max 5 --cpu-percent=40
+```{{execute}}
+
+All set! Now the Web UI can scale automatically to multiple instances if the load on the CoolStore 
+online store increases. You can verify that using for example `ab` the 
+[Apache HTTP server benchmarking tool](https://httpd.apache.org/docs/2.4/programs/ab.html). Let's 
+deploy the `ab` container image from [Docker Hub](https://hub.docker.com/r/jordi/ab/) and 
+generate some load on the Web UI:
+
+```
+oc run web-load --restart='OnFailure' --image=jordi/ab -- -n 100000 -c 20 http://web:8080/
+```{{execute}}
+
+OpenShift will first looks in the internal image registry and then in defined upstream registries 
+([Red Hat Container Catalog](https://access.redhat.com/search/#/container-images) and 
+[Docker Hub](https://hub.docker.com) by default) to find and pull this image. 
+
+As the load is generated, you will notice that it will create a spike in the 
+Web UI cpu usage and trigger the autoscaler to scale the Web UI container to 5 pods (as configured 
+on the deployment config) to cope with the load.
+
+Depending on the resources available on the OpenShift cluster, the pod might scale 
+to fewer than 5 pods. to handle the extra load. You can increase the load by 
+specifying a higher number of requests with the `-n` flag.
+
+![Web UI Automatically Scaled](https://katacoda.com/openshift-roadshow/assets/fault-autoscale-web.png)

--- a/scenarios-3.9/fault-tolerance/05-monitor-scaled.md
+++ b/scenarios-3.9/fault-tolerance/05-monitor-scaled.md
@@ -1,0 +1,8 @@
+You can see the aggregated cpu metrics graph of all 5 Web UI pods by going
+ to the OpenShift Web Console and clicking on **Monitoring** and then 
+ the arrow (**>**) on the left side of **web-n** under **Deployments**.
+
+![Web UI Aggregated CPU Metrics](https://katacoda.com/openshift-roadshow/assets/fault-autoscale-metrics.png)
+
+When the load on Web UI disappears, after a while OpenShift scales the Web UI pods down to the minimum 
+or whatever this needed to cope with the load at that point.

--- a/scenarios-3.9/fault-tolerance/06-self-healing-intro.md
+++ b/scenarios-3.9/fault-tolerance/06-self-healing-intro.md
@@ -1,0 +1,35 @@
+We looked at how to build more resilience into the applications through scaling in the 
+previous sections. In this section, you will learn how to recover application pods when 
+failures happen. In fact, you don't need to do anything because OpenShift automatically 
+recovers failed pods when pods are not feeling healthy. The healthiness of application pods is determined via the 
+[health probes](https://docs.openshift.com/container-platform/3.7/dev_guide/application_health.html#container-health-checks-using-probes) 
+which was discussed in the previous scenarios.
+
+There are three auto-healing scenarios that OpenShift handles automatically:
+
+* **Application Pod Temporary Failure** 
+
+  When an application pod fails and does not pass its 
+  [liveness health probe](https://docs.openshift.com/container-platform/3.7/dev_guide/application_health.html#container-health-checks-using-probes),  
+  OpenShift restarts the pod in order to give the application a chance to recover and start functioning 
+  again. Issues such as deadlocks, memory leaks, network disturbance and more are all examples of issues 
+  than can most likely be resolved by restarting the application despite the potential bug remaining in the 
+  application.
+
+* **Application Pod Permanent Failure** 
+
+  When an application pod fails and does not pass its 
+  [readiness health probe](https://docs.openshift.com/container-platform/3.7/dev_guide/application_health.html#container-health-checks-using-probes), 
+  it signals that the failure is more severe and restart does not help to mitigate the issue. OpenShift then 
+  removes the application pod from the load-balancer to prevent sending traffic to it.
+
+* **Application Pod Removal** 
+
+  If an instance of the application pod get removed, OpenShift automatically 
+  starts new identical application pods based on the same container image and configuration so that the 
+  specified number of instances all running at all times. An example of a removed pod is when an entire 
+  node (virtual or physical machine) crashes and is removed from the cluster.
+
+OpenShift is quite orderly in this regard and if extra instances of the application pod would start running, 
+it would kill the extra pods so that the number of running instances matches what is 
+configured on the deployment config.

--- a/scenarios-3.9/fault-tolerance/07-self-healing-define.md
+++ b/scenarios-3.9/fault-tolerance/07-self-healing-define.md
@@ -1,0 +1,31 @@
+All of the above comes out-of-the-box and don't need any extra configuration. Remove the Catalog 
+pod to verify how OpenShift starts the pod again. First, check the Catalog pod that is running:
+
+```
+oc get pods -l deploymentconfig=catalog
+```{{execute}}
+
+The `-l` options tells the command to list pods that have the `deploymentconfig=catalog` label 
+assigned to them. You can see pods labels using `oc get pods --show-labels` command.
+
+Delete the Catalog pod.
+
+```
+oc delete pods -l deploymentconfig=catalog
+```{{execute}}
+
+You need to be fast for this one! List the Catalog pods again immediately:
+
+```
+oc get pods -l deploymentconfig=catalog
+```{{execute}}
+
+As the Catalog pod is being deleted, OpenShift notices the lack of 1 pod and starts a new Catalog 
+pod automatically.
+
+```
+NAME         READY  STATUS
+catalog-3-5  0/1    ContainerCreating
+catalog-3-x  0/1    Terminating
+```
+

--- a/scenarios-3.9/fault-tolerance/08-cascading-failures.md
+++ b/scenarios-3.9/fault-tolerance/08-cascading-failures.md
@@ -1,0 +1,21 @@
+In this scenario so far you have been looking how to make sure the application pod is running, can scale to accommodate
+user load and recovers from failures. However failures also happen in the downstream services that an application
+is dependent on. It's not uncommon that the whole application fails or slows down because one of the downstream
+services consumed by the application is not responsive or responds slowly.
+
+[Circuit Breaker](https://martinfowler.com/bliki/CircuitBreaker.html) is a pattern to address this issue and while
+became popular with microservice architecture, it's a useful pattern for all applications that depend on other
+services.
+
+The idea behind the circuit breaker is that you wrap the API calls to downstream services in a circuit breaker
+object, which monitors for failures. Once the service invocation fails certain number of times, the circuit
+breaker flips open, and all further calls to the circuit breaker return with an error or a fallback logic
+without making the call to the unresponsive API. After a certain period, the circuit breaker for allow a call
+to the downstream service to test the waters. If the call success, the circuit breaker closes and would call
+the downstream service on consequent calls.
+
+![Circuit Breaker](https://katacoda.com/openshift-roadshow/assets/fault-circuit-breaker.png)
+
+Spring Boot and WildFly Swarm provide convenient integration with [Hystrix](https://github.com/Netflix/Hystrix)
+which is a framework that provides circuit breaker functionality. Eclipse Vert.x, in addition to integration
+with Hystrix, provides built-in support for circuit breakers.

--- a/scenarios-3.9/fault-tolerance/09-circuit-breaker.md
+++ b/scenarios-3.9/fault-tolerance/09-circuit-breaker.md
@@ -1,0 +1,15 @@
+Let's take the Inventory service down and see what happens to the CoolStore online shop.
+
+```
+oc scale dc/inventory --replicas=0
+```{{execute}}
+
+Now point your browser at the Web UI route url.
+
+> You can find the Web UI route url in the OpenShift Web Console above the **web** pod or
+> using the `oc get routes` command.
+
+![CoolStore Without Circuit Breaker](https://katacoda.com/openshift-roadshow/assets/fault-coolstore-no-cb.png)
+
+Although only the Inventory service is down, there are no products displayed in the online store because
+the Inventory service call failure propagates and causes the entire API Gateway to blow up!

--- a/scenarios-3.9/fault-tolerance/10-circuit-breaker-add.md
+++ b/scenarios-3.9/fault-tolerance/10-circuit-breaker-add.md
@@ -1,0 +1,137 @@
+The CoolStore online shop cannot function without the products list, however the inventory status is not a
+crucial bit in the shopping experience. Let's add a circuit breaker for calls to the Inventory service and
+provide a default inventory status when the Inventory service is not responsive.
+
+In the **gateway-vertx** project, replace the `GatewayVerticle.java` code with
+the following by clicking on *Copy to Editor*:
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/gateway/GatewayVerticle.java" data-target="replace">
+package com.redhat.cloudnative.gateway;
+
+import io.vertx.circuitbreaker.CircuitBreakerOptions;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.rxjava.circuitbreaker.CircuitBreaker;
+import io.vertx.rxjava.core.AbstractVerticle;
+import io.vertx.rxjava.ext.web.Router;
+import io.vertx.rxjava.ext.web.RoutingContext;
+import io.vertx.rxjava.ext.web.client.WebClient;
+import io.vertx.rxjava.ext.web.codec.BodyCodec;
+import io.vertx.rxjava.ext.web.handler.CorsHandler;
+import io.vertx.rxjava.servicediscovery.ServiceDiscovery;
+import io.vertx.rxjava.servicediscovery.types.HttpEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Single;
+
+public class GatewayVerticle extends AbstractVerticle {
+    private static final Logger LOG = LoggerFactory.getLogger(GatewayVerticle.class);
+
+    private WebClient catalog;
+    private WebClient inventory;
+    private CircuitBreaker circuit;
+
+    @Override
+    public void start() {
+
+        circuit = CircuitBreaker.create("inventory-circuit-breaker", vertx,
+            new CircuitBreakerOptions()
+                .setFallbackOnFailure(true)
+                .setMaxFailures(3)
+                .setResetTimeout(5000)
+                .setTimeout(1000)
+        );
+
+        Router router = Router.router(vertx);
+        router.route().handler(CorsHandler.create("*").allowedMethod(HttpMethod.GET));
+        router.get("/health").handler(ctx -> ctx.response().end(new JsonObject().put("status", "UP").toString()));
+        router.get("/api/products").handler(this::products);
+
+        ServiceDiscovery.create(vertx, discovery -> {
+            // Catalog lookup
+            Single&lt;WebClient&gt; catalogDiscoveryRequest = HttpEndpoint.rxGetWebClient(discovery,
+                    rec -> rec.getName().equals("catalog"))
+                    .onErrorReturn(t -> WebClient.create(vertx, new WebClientOptions()
+                            .setDefaultHost(System.getProperty("catalog.api.host", "localhost"))
+                            .setDefaultPort(Integer.getInteger("catalog.api.port", 9000))));
+
+            // Inventory lookup
+            Single&lt;WebClient&gt; inventoryDiscoveryRequest = HttpEndpoint.rxGetWebClient(discovery,
+                    rec -> rec.getName().equals("inventory"))
+                    .onErrorReturn(t -> WebClient.create(vertx, new WebClientOptions()
+                            .setDefaultHost(System.getProperty("inventory.api.host", "localhost"))
+                            .setDefaultPort(Integer.getInteger("inventory.api.port", 9001))));
+
+            // Zip all 3 requests
+            Single.zip(catalogDiscoveryRequest, inventoryDiscoveryRequest, (c, i) -> {
+                // When everything is done
+                catalog = c;
+                inventory = i;
+                return vertx.createHttpServer()
+                    .requestHandler(router::accept)
+                    .listen(Integer.getInteger("http.port", 8080));
+            }).subscribe();
+        });
+    }
+
+    private void products(RoutingContext rc) {
+        // Retrieve catalog
+        catalog.get("/api/catalog").as(BodyCodec.jsonArray()).rxSend()
+            .map(resp -> {
+                if (resp.statusCode() != 200) {
+                    new RuntimeException("Invalid response from the catalog: " + resp.statusCode());
+                }
+                return resp.body();
+            })
+            .flatMap(products ->
+                // For each item from the catalog, invoke the inventory service
+                Observable.from(products)
+                    .cast(JsonObject.class)
+                    .flatMapSingle(product ->
+                        circuit.rxExecuteCommandWithFallback(
+                            future ->
+                                inventory.get("/api/inventory/" + product.getString("itemId")).as(BodyCodec.jsonObject())
+                                    .rxSend()
+                                    .map(resp -> {
+                                        if (resp.statusCode() != 200) {
+                                            LOG.warn("Inventory error for {}: status code {}",
+                                                    product.getString("itemId"), resp.statusCode());
+                                        }
+                                        return product.copy().put("availability",
+                                            new JsonObject().put("quantity", resp.body().getInteger("quantity")));
+                                    })
+                                    .subscribe(
+                                        future::complete,
+                                        future::fail),
+                            error -> {
+                                LOG.error("Inventory error for {}: {}", product.getString("itemId"), error.getMessage());
+                                return product;
+                            }
+                        ))
+                    .toList().toSingle()
+            )
+            .subscribe(
+                list -> rc.response().end(Json.encodePrettily(list)),
+                error -> rc.response().end(new JsonObject().put("error", error.getMessage()).toString())
+            );
+    }
+}
+</pre>
+
+The above code wraps the calls to the Inventory
+service in a `CircuitBreaker` using the built-in circuit breaker in 
+Vert.x. The circuit breaker is configured to flip open after 3 
+failures and time out on the calls after 1 second.
+
+The `circuit.rxExecuteCommandWithFallback(...)` method, defines the fallback logic for
+when the circuit is open and logs an error without calling the Inventory service in those
+scenarios.
+
+Build the API Gateway using Maven.
+
+```
+mvn package
+```{{execute}}

--- a/scenarios-3.9/fault-tolerance/11-deploy-gateway.md
+++ b/scenarios-3.9/fault-tolerance/11-deploy-gateway.md
@@ -1,0 +1,30 @@
+
+You can now trigger a new container image build on OpenShift using 
+the `oc start-build` command which allows you to build container images directly from the application 
+archives (jar, war, etc) without the need to have access to the source code for example by downloading 
+the jar archive form the Maven repository (e.g. Nexus, Artifactory).
+
+```
+oc start-build gateway-s2i --from-file=target/gateway-1.0-SNAPSHOT.jar
+```{{execute}}
+
+As soon as the new **gateway** container image is built, OpenShift deploys the new image automatically 
+thanks to the [deployment triggers](https://docs.openshift.com/container-platform/3.7/dev_guide/deployments/basic_deployment_operations.html#triggers) 
+defined on the **gateway** deployment config.
+
+Let's try the Web UI again in the browser while the Inventory service is still down.
+
+![CoolStore With Circuit Breaker](https://katacoda.com/openshift-roadshow/assets/fault-coolstore-with-cb.png)
+
+It looks better now! The Inventory service failure is contained and the inventory status is removed from the 
+user interface and allows the CoolStore online shop to continue functioning and accept orders. Selling an 
+out-of-stock product to a few customers can simply be resolved by a discount coupons while 
+losing the trust of all visiting customers due to a crashed online store is not so easily repairable!
+
+Scale the Inventory service back up before moving on to the next scenarios.
+
+```
+oc scale dc/inventory --replicas=1
+```{{execute}}
+
+Well done!

--- a/scenarios-3.9/fault-tolerance/99-outro.md
+++ b/scenarios-3.9/fault-tolerance/99-outro.md
@@ -1,0 +1,2 @@
+Move on to the next scenario, **Managing Application Configuration** to learn 
+how to externalize application configurations.

--- a/scenarios-3.9/fault-tolerance/index.json
+++ b/scenarios-3.9/fault-tolerance/index.json
@@ -1,0 +1,80 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Service Resilience and Fault Tolerance",
+    "description": "",
+    "difficulty": "beginner",
+    "time": "15-20 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Scaling Applications",
+                "text": "01-scale-intro.md"
+            },
+            {
+                "title": "Scale Web UI",
+                "text": "02-scale-web.md"
+            },
+            {
+                "title": "Autoscaling",
+                "text": "03-autoscale-intro.md"
+            },
+            {
+                "title": "Define an Autoscaler",
+                "text": "04-autoscale-define.md"
+            },
+            {
+                "title": "Scaled Container Metrics",
+                "text": "05-monitor-scaled.md"
+            },
+            {
+                "title": "Self-healing",
+                "text": "06-self-healing-intro.md"
+            },
+            {
+                "title": "Self-healing",
+                "text": "07-self-healing-define.md"
+            },
+            {
+                "title": "Cascading Failures",
+                "text": "08-cascading-failures.md"
+            },
+            {
+                "title": "Circuit Breakers",
+                "text": "09-circuit-breaker.md"
+            },
+            {
+                "title": "Circuit Breakers",
+                "text": "10-circuit-breaker-add.md"
+            },
+            {
+                "title": "Deploy API Gateway",
+                "text": "05-deploy-gateway.md"
+            }
+        ],
+        "intro": {
+            "courseData": "run-init.sh",
+            "code": "run-prep-lab.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+            "text": "99-outro.md"
+        }
+    },
+    "files": [
+      "./src/main/java/com/redhat/cloudnative/gateway/GatewayVerticle.java"
+    ],
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideintro": false,
+        "uisettings": "java",
+        "uieditorpath": "/root/gateway-vertx",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/fault-tolerance/run-prep-lab.sh
+++ b/scenarios-3.9/fault-tolerance/run-prep-lab.sh
@@ -1,0 +1,1 @@
+cd ~/gateway-vertx

--- a/scenarios-3.9/getting-started/00-intro.md
+++ b/scenarios-3.9/getting-started/00-intro.md
@@ -1,0 +1,2 @@
+In this scenario you will get familiar with the OpenShift CLI and OpenShift Web Console 
+and get ready for the rest of Cloud Native Roadshow scenarios.

--- a/scenarios-3.9/getting-started/01-login-verify.sh
+++ b/scenarios-3.9/getting-started/01-login-verify.sh
@@ -1,0 +1,1 @@
+[ `oc whoami` == "developer" ] && echo "done"

--- a/scenarios-3.9/getting-started/01-login.md
+++ b/scenarios-3.9/getting-started/01-login.md
@@ -1,0 +1,20 @@
+OpenShift ships with a feature rich web console as well as command line tools
+to provide users with a nice interface to work with applications deployed to the
+platform. The OpenShift tools are a single executable written in the Go
+programming language and is available for Microsoft Windows, Apple OS X and Linux.
+
+In order to login, we will use the **oc** command and then specify the server that we
+want to authenticate to:
+
+```
+oc login [[HOST_SUBDOMAIN]]-8443-[[KATACODA_HOST]].environments.katacoda.com
+```{{execute}}
+
+You might get a question wether to use an insecure connection. Enter `y` and then enter 
+your username and password:
+* Username: **developer**
+* Password: **developer**
+
+Congratulations, you are now authenticated to the OpenShift server.
+
+> You can verify that you are logged in as **developer** using `oc whoami`

--- a/scenarios-3.9/getting-started/02-create-project.md
+++ b/scenarios-3.9/getting-started/02-create-project.md
@@ -1,0 +1,14 @@
+[Projects](https://docs.openshift.com/container-platform/3.7/architecture/core_concepts/projects_and_users.html#projects) 
+are a top level concept to help you organize your deployments. An
+OpenShift project allows a community of users (or a user) to organize and manage
+their content in isolation from other communities. Each project has its own
+resources, policies (who can or cannot perform actions), and constraints (quotas
+and limits on resources, etc). Projects act as a wrapper around all the
+application services and endpoints you (or your teams) are using for your work.
+
+For this scenario, let's create a project that you will use in the following scenarios for 
+deploying your applications. 
+
+```
+oc new-project coolstore
+```{{execute}}

--- a/scenarios-3.9/getting-started/03-projects-console.md
+++ b/scenarios-3.9/getting-started/03-projects-console.md
@@ -1,0 +1,16 @@
+OpenShift ships with a web-based console that will allow users to
+perform various tasks via a browser. To get a feel for how the web console
+works, open a new browser tab and go to the OpenShift Web Console:
+
+```
+https://[[HOST_SUBDOMAIN]]-8443-[[KATACODA_HOST]].environments.katacoda.com
+```{{copy}}
+
+The first screen you will see is the authentication screen. Enter your username and password and 
+then log in. After you have authenticated to the web console, you will be presented with a
+list of projects that your user has permission to work with.
+
+Click on the **coolstore** project to be taken to the project overview page
+which will list all of the routes, services, deployments, and pods that you have
+running as part of your project. There's nothing there now, but that's about to
+change.

--- a/scenarios-3.9/getting-started/04-maven-projects.md
+++ b/scenarios-3.9/getting-started/04-maven-projects.md
@@ -1,0 +1,11 @@
+In order to get started, you need a few project skeletons to skip building those during 
+the scenario. The skeletons are already available in your home directly.
+
+Explore the list of project skeletons:
+
+```
+ls -l
+```{{execute}}
+
+You will use these projects in the following scenarios to build microservices 
+using WildFly Swarm, Spring Boot and Eclipse Vert.x

--- a/scenarios-3.9/getting-started/99-outro.md
+++ b/scenarios-3.9/getting-started/99-outro.md
@@ -1,0 +1,2 @@
+You are now ready to start building a microservices 
+application. Start with **Enterprise Microservices with WildFly Swarm**

--- a/scenarios-3.9/getting-started/index.json
+++ b/scenarios-3.9/getting-started/index.json
@@ -1,0 +1,47 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Getting Started with OpenShift",
+    "description": "",
+    "difficulty": "beginner",
+    "time": "5-10 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Explore OpenShift CLI",
+                "text": "01-login.md"
+            },
+            {
+                "title": "Create an OpenShift Project",
+                "text": "02-create-project.md"
+            },
+            {
+                "title": "Projects in OpenShift Web Console",
+                "text": "03-projects-console.md"
+            },
+            {
+                "title": "Explore Maven Projects",
+                "text": "04-maven-projects.md"
+            }
+        ],
+        "intro": {
+            "courseData": "run-init.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+          "text": "99-outro.md"
+        }
+    },
+    "environment": {
+        "uilayout": "terminal",
+        "uisettings": "javascript",
+        "showdashboard": true,
+        "hideintro": false,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/manage-config/00-intro.md
+++ b/scenarios-3.9/manage-config/00-intro.md
@@ -1,0 +1,3 @@
+In this scenario you will learn how to manage application configuration and how to provide 
+environment-specific configuration to the services without making them dependent on their 
+environment.

--- a/scenarios-3.9/manage-config/01-inmemory-db.md
+++ b/scenarios-3.9/manage-config/01-inmemory-db.md
@@ -1,0 +1,17 @@
+So far Catalog and Inventory services have been using an in-memory H2 database. Although H2 
+is a convenient database to run locally on your laptop, it's in no ways appropriate for production or 
+even integration tests. Since it's strongly recommended to use the same technology stack (operating 
+system, JVM, middleware, database, etc) that is used in production across all environments, you 
+should modify Inventory and Catalog services to use PostgreSQL instead of the H2 in-memory database.
+
+Fortunately, OpenShfit supports stateful applications such as databases which required access to 
+a persistent storage that survives the container itself. You can deploy databases on OpenShift and 
+regardless of what happens to the container itself, the data is safe and can be used by the next 
+database container.
+
+In this scenario you will deploy 2 PostgreSQL databases for the Catalog and Inventory services 
+using the templates. [OpenShift Templates](https://docs.openshift.com/container-platform/3.7/dev_guide/templates.html) 
+use YAML/JSON to compose multiple containers and their configurations as a list of objects to 
+be created and deployed at once hence making it simple to re-create complex deployments by just 
+deploying a single template. Templates can be parameterized to get input for fields like service 
+names and generate values for fields like passwords.

--- a/scenarios-3.9/manage-config/02-create-psql.md
+++ b/scenarios-3.9/manage-config/02-create-psql.md
@@ -1,0 +1,29 @@
+Let's create a [PostgreSQL database](https://docs.openshift.com/container-platform/3.7/using_images/db_images/postgresql.html) 
+for the Inventory service using the PostgreSQL template that is provided out-of-the-box
+```
+oc new-app postgresql-persistent \
+    --param=DATABASE_SERVICE_NAME=inventory-postgresql \
+    --param=POSTGRESQL_DATABASE=inventory \
+    --param=POSTGRESQL_USER=inventory \
+    --param=POSTGRESQL_PASSWORD=inventory \
+    --labels=app=inventory
+```{{execute}}
+
+The `--param` parameter provides a value for the template parameters. The recommended approach is 
+not to provide any value for username and password and allow the template to generate a random value for 
+you due to security reasons. In this scenario in order to reduce typos, a fixed value is provided for username and 
+password. The **--labels** allows assigning arbitrary key-value labels to the application objects in order to make it easier to 
+find them later on when you have many applications in the same project.
+
+Deploy another PostgreSQL database for the Catalog service:
+
+```
+oc new-app postgresql-persistent \
+    --param=DATABASE_SERVICE_NAME=catalog-postgresql \
+    --param=POSTGRESQL_DATABASE=catalog \
+    --param=POSTGRESQL_USER=catalog \
+    --param=POSTGRESQL_PASSWORD=catalog \
+    --labels=app=catalog
+```{{execute}}
+
+Now you can move on to configure the Inventory and Catalog service to use these PostgreSQL databases.

--- a/scenarios-3.9/manage-config/03-inventory-config-create.md
+++ b/scenarios-3.9/manage-config/03-inventory-config-create.md
@@ -1,0 +1,52 @@
+WildFly Swarm supports multiple mechanisms for externalizing configurations such as environment variables, 
+Maven properties, command-line arguments and more. The recommend approach for the long-term for externalizing 
+configuration is however using a [YAML file](https://reference.wildfly-swarm.io/configuration.html#_using_yaml) 
+which you have already packaged within the Inventory Maven project.
+
+The YAML file can be packaged within the application JAR file and be overladed 
+[using command-line or system properties](https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/configuration/project_stages.html#_command_line_switches_system_properties) which you will do in this scenario.
+
+Check out `project-stages.yml` in Inventory Maven project which contains the default configuration:
+
+```
+cat inventory-wildfly-swarm/src/main/resources/project-stages.yml
+```{{execute}}
+
+Create a YAML file with the PostgreSQL database credentials by clicking on *Copy to Editor*. 
+Note that you can give an arbitrary name to this configuration 
+(e.g. **prod** in order to tell WildFly Swarm which one to use:
+
+<pre class="file" data-filename="./project-stages.yml" data-target="replace">
+project:
+  stage: prod
+swarm:
+  datasources:
+    data-sources:
+      InventoryDS:
+        driver-name: postgresql
+        connection-url: jdbc:postgresql://inventory-postgresql:5432/inventory
+        user-name: inventory
+        password: inventory
+</pre>
+
+The hostname defined for the PostgreSQL connection-url corresponds to the PostgreSQL 
+service name published on OpenShift. This name will be resolved by the internal DNS server 
+exposed by OpenShift and accessible to containers running on OpenShift.
+
+And then create a config map that you will use to overlay on the default `project-stages.yml` which is 
+packaged in the Inventory JAR archive:
+
+```
+oc create configmap inventory \
+   --from-file=./project-stages.yml
+```{{execute}}
+
+Config maps hold key-value pairs and in the above command an `inventory` config map 
+is created with `project-stages.yml` as the key and the content of the `project-stages.yml` as the 
+value. Whenever a config map is injected into a container, it would appear as a file with the same 
+name as the key, at path on the filesystem.
+
+You can see the content of the config map in the OpenShift Web Console or via CLI:
+```
+oc describe cm inventory
+```{{execute}}

--- a/scenarios-3.9/manage-config/04-inventory-config-mount.md
+++ b/scenarios-3.9/manage-config/04-inventory-config-mount.md
@@ -1,0 +1,27 @@
+Modify the Inventory deployment config so that it injects the YAML configuration you just created as 
+a config map into the Inventory container:
+
+```
+oc volume dc/inventory \
+   --add \
+   --configmap-name=inventory \
+   --mount-path=/app/config
+```{{execute}}
+
+The above command mounts the content of the `inventory` config map as a file inside the Inventory container 
+at `/app/config/project-stages.yaml`
+
+The last step is the [aforementioned system properties](https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/configuration/project_stages.html#_command_line_switches_system_properties) on the Inventory container to overlay the 
+WildFly Swarm configuration, using the **JAVA_OPTIONS** environment variable. 
+
+> The Java runtime on OpenShift can be configured using 
+> [a set of environment variables](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/reference#configuration_environment_variables) 
+> to tune the JVM without the need to rebuild a new Java runtime container image every time a new option is needed.
+
+```
+oc set env dc/inventory \
+   JAVA_OPTIONS="-Dswarm.project.stage=prod -Dswarm.project.stage.file=file:///app/config/project-stages.yml"
+```{{execute}}
+
+The Inventory pod gets restarted automatically due to the configuration changes. Wait till it's ready 
+before going to the next step.

--- a/scenarios-3.9/manage-config/05-inventory-config-verify.md
+++ b/scenarios-3.9/manage-config/05-inventory-config-verify.md
@@ -1,0 +1,53 @@
+When the Inventory pod is ready, verify that the config map is in fact injected 
+into the container by running a shell command inside the Inventory container:
+
+```
+oc --server https://master:8443 rsh dc/inventory cat /app/config/project-stages.yml
+```{{execute}}
+
+Also verify that the PostgreSQL database is actually used by the Inventory service. Check the 
+Inventory pod logs:
+
+```
+oc logs dc/inventory | grep hibernate.dialect
+```{{execute}}
+
+You would see the **PostgreSQL94Dialect** is selected by Hibernate in the logs:
+
+```
+2017-08-10 16:55:44,657 INFO  [org.hibernate.dialect.Dialect] (ServerService Thread Pool -- 15) HHH000400: Using dialect: org.hibernate.dialect.PostgreSQL94Dialect
+```
+
+You can also connect to Inventory PostgreSQL database and check if the seed data is 
+loaded into the database:
+
+```
+oc --server https://master:8443 rsh dc/inventory-postgresql
+```{{execute}}
+
+Once connected to the PostgreSQL container, run the following inside the 
+Inventory PostgreSQL container:
+
+```
+psql -U inventory -c "select * from inventory"
+```{{execute}}
+
+You should see the seed data gets listed.
+
+```
+ itemid | quantity
+------------------
+ 329299 |       35
+ 329199 |       12
+ ...
+```
+
+Exit the container shell.
+
+```
+exit
+```{{execute}}
+
+You have now created a config map that holds the configuration content for Inventory and can be updated 
+at anytime for example when promoting the container image between environments without needing to 
+modify the Inventory container image itself. 

--- a/scenarios-3.9/manage-config/06-catalog-config.md
+++ b/scenarios-3.9/manage-config/06-catalog-config.md
@@ -1,0 +1,58 @@
+You should be quite familiar with config maps by now. Spring Boot application configuration is provided 
+via a properties filed called `application.properties` and can be 
+[overriden and overlayed via multiple mechanisms](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html). 
+
+Check out the default Spring Boot configuration `application.properties` in Catalog Maven project: 
+
+```
+cat catalog-spring-boot/src/main/resources/application.properties
+```{{execute}}
+
+In this scenario, you will configure the Catalog service which is based on Spring Boot to override the default 
+configuration using an alternative `application.properties` backed by a config map.
+
+Create a properties file with the Spring Boot configuration content using the PostgreSQL database 
+credentials by clicking on *Copy to Editor*:
+
+<pre class="file" data-filename="./application.properties" data-target="replace">
+spring.datasource.url=jdbc:postgresql://catalog-postgresql:5432/catalog
+spring.datasource.username=catalog
+spring.datasource.password=catalog
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=create
+</pre>
+
+> The hostname defined for the PostgreSQL connection-url corresponds to the PostgreSQL 
+service name published on OpenShift. This name will be resolved by the internal DNS server 
+exposed by OpenShift and accessible to containers running on OpenShift.
+
+```
+oc create configmap catalog \
+      --from-file=./application.properties
+```{{execute}}
+
+The [Spring Cloud Kubernetes](https://github.com/spring-cloud-incubator/spring-cloud-kubernetes) plug-in implements 
+the integration between Kubernetes and Spring Boot and is already added as a dependency to the Catalog Maven 
+project. Using this dependency, Spring Boot would search for a config map (by default with the same name as 
+the application) to use as the source of application configurations during application bootstrapping and 
+if enabled, triggers hot reloading of beans or Spring context when changes are detected on the config map.
+
+Although Spring Cloud Kubernetes tries to discover config maps, due to security reasons containers 
+by default are not allowed to snoop around OpenShift clusters and discover objects. Security comes first, 
+and discovery is a privilege that needs to be granted to containers in each project. 
+
+Since you do want Spring Boot to discover the config maps inside the **coolstore** project, you 
+need to grant permission to the Spring Boot service account to access the OpenShift REST API and find the 
+config maps. However you have done this already in previous scenarios using the 
+`oc policy` command.
+
+Delete the Catalog container to make it start again and look for the config maps:
+
+```
+oc delete pod -l deploymentconfig=catalog
+```{{execute}}
+
+The `-l deploymentconfig=catalog` means filter pods and only delete the ones that 
+have the label `deploymentconfig` with the value `catalog`
+
+Wait till the Catalog pod is ready before going to the next step.

--- a/scenarios-3.9/manage-config/07-catalog-config-verify.md
+++ b/scenarios-3.9/manage-config/07-catalog-config-verify.md
@@ -1,0 +1,42 @@
+When the Catalog pod is ready, verify that the PostgreSQL database is being 
+used. Check the Catalog pod logs:
+
+```
+oc logs dc/catalog | grep hibernate.dialect
+```{{execute}}
+
+You would see the **PostgreSQL94Dialect** is selected by Hibernate in the logs:
+
+```
+2017-08-10 21:07:51.670  INFO 1 --- [           main] org.hibernate.dialect.Dialect            : HHH000400: Using dialect: org.hibernate.dialect.PostgreSQL94Dialect
+```
+
+You can also connect to the Catalog PostgreSQL database and verify that the seed data is loaded:
+
+```
+oc --server https://master:8443 rsh dc/catalog-postgresql
+```{{execute}}
+
+Once connected to the PostgreSQL container, run the following:
+
+> Run this command inside the Catalog PostgreSQL container, after opening a remote shell to it.
+
+```
+psql -U catalog -c "select item_id, name, price from product"
+```{{execute}}
+
+You should see the seed data gets listed.
+
+```
+ item_id |            name             | price
+----------------------------------------------
+ 329299  | Red Fedora                  | 34.99
+ 329199  | Forge Laptop Sticker        |   8.5
+ ...
+```
+
+Exit the container shell.
+
+```
+exit
+```{{execute}}

--- a/scenarios-3.9/manage-config/08-secrets.md
+++ b/scenarios-3.9/manage-config/08-secrets.md
@@ -1,0 +1,33 @@
+Config map is a superb mechanism for externalizing application configuration while keeping 
+containers independent of in which environment or on what container platform they are running. 
+Nevertheless, due their clear-text nature, they are not suitable for sensitive data like 
+database credentials, SSH certificates, etc. In the current scenario, we used config maps for database 
+credentials to simplify the steps however for production environments, you should opt for a more 
+secure way to handle sensitive data.
+
+Fortunately, OpenShift already provides a secure mechanism for handling sensitive data which is 
+called [Secrets](https://docs.openshift.com/container-platform/3.7/dev_guide/secrets.html). Secret objects act and are used 
+similar to config maps however with the difference that they are encrypted as they travel over the wire 
+and also at rest when kept on a persistent disk. Like config maps, secrets can be injected into 
+containers a environment variables or files on the filesystem using a temporary file-storage 
+facility (tmpfs).
+
+You won't create any secrets in this scenario however you have already created 2 secrets when you created 
+the PostgreSQL databases for Inventory and Catalog services. The PostgreSQL template by default stores 
+the database credentials in a secret in the project it's being created:
+
+```
+oc describe secret catalog-postgresql
+```{{execute}}
+
+This secret has two encrypted properties defined as **database-user** and **database-password** which hold 
+the PostgreSQL username and password values. These values are injected in the PostgreSQL container as 
+environment variables and used to initialize the database.
+
+Go to the **coolstore** in the OpenShift Web Console and click on the **catalog-postgresql**
+deployment (blue text under the title **Deployment**) and then on the ** Environment**. Notice the values 
+from the secret are defined as env vars on the deployment:
+
+![Secrets as Env Vars](https://katacoda.com/openshift-roadshow/assets/config-psql-secret.png)
+
+That's all for this scenario! You are ready to move on to the next scenario.

--- a/scenarios-3.9/manage-config/99-outro.md
+++ b/scenarios-3.9/manage-config/99-outro.md
@@ -1,0 +1,2 @@
+Move on to the next scenario, **Continuous Delivery** to build a delivery pipeline for 
+the Inventory service.

--- a/scenarios-3.9/manage-config/index.json
+++ b/scenarios-3.9/manage-config/index.json
@@ -1,0 +1,67 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Managing Application Configurations",
+    "description": "",
+    "difficulty": "intermediate",
+    "time": "15-20 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Stateful Applications",
+                "text": "01-inmemory-db.md"
+            },
+            {
+                "title": "Deploy PostgreSQL Templates",
+                "text": "02-create-psql.md"
+            },
+            {
+                "title": "Externalize Inventory Config",
+                "text": "03-inventory-config-create.md"
+            },
+            {
+                "title": "Externalize Inventory Config",
+                "text": "04-inventory-config-mount.md"
+            },
+            {
+                "title": "Verify Inventory Config",
+                "text": "05-inventory-config-verify.md"
+            },
+            {
+                "title": "Externalize Catalog Config",
+                "text": "06-catalog-config.md"
+            },
+            {
+                "title": "Verify Catalog Config",
+                "text": "07-catalog-config-verify.md"
+            },
+            {
+                "title": "Sensitive Config Data",
+                "text": "08-secrets.md"
+            }
+        ],
+        "intro": {
+            "courseData": "run-init.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+            "text": "99-outro.md"
+        }
+    },
+    "files": [
+      "./application.properties",
+      "./project-stages.yml"
+    ],
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideintro": false,
+        "uisettings": "java",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/microservice-nodejs/00-intro.md
+++ b/scenarios-3.9/microservice-nodejs/00-intro.md
@@ -1,0 +1,16 @@
+In this scenario you will learn about Node.js and will deploy the Node.js and Angular-based 
+web front+end for the CoolStore online shop which uses the API Gateway services you deployed 
+in previous scenarios. 
+
+![API Gateway Pattern](https://katacoda.com/openshift-roadshow/assets/coolstore-arch.png)
+
+## What is Node.js?
+
+Node.js is an open source, cross-platform runtime environment for developing server-side 
+applications using JavaScript. Node.js has an event-driven architecture capable of 
+non-blocking I/O. These design choices aim to optimize throughput and scalability in 
+Web applications with many input/output operations, as well as for real-time web applications.
+
+Node.js non-blocking architectures allows applications to process large number of 
+requests (tens of thousands) using a single thread which makes ia desirable choice for building 
+scalable web applications.

--- a/scenarios-3.9/microservice-nodejs/01-deploy.md
+++ b/scenarios-3.9/microservice-nodejs/01-deploy.md
@@ -1,0 +1,26 @@
+The Web UI is built using Node.js for server-side JavaScript and AngularJS for client-side 
+JavaScript. Let's deploy it on OpenShift using the certified Node.js container image available 
+in OpenShift. 
+
+In the previous scenarios, you used the OpenShift 
+[Source-to-Image (S2I)](https://docs.openshift.com/container-platform/3.7/architecture/core_concepts/builds_and_image_streams.html#source-build) 
+feature via the [Fabric8 Maven Plugin](https://maven.fabric8.io) to build a container image from the 
+source code on your laptop. In this scenario, you will still use S2I but instead instruct OpenShift 
+to obtain the application code directly from the source repository and build and deploy a 
+container image of it.
+
+The source code for the the Node.js Web front-end is available in this Git repository: 
+<https://github.com/openshift-labs/cloud-native-labs/tree/master/web-nodejs>
+
+Use the OpenShift CLI command to create a new build and deployment for the Web component:
+
+```
+oc new-app nodejs~https://github.com/openshift-labs/cloud-native-labs.git \
+        --context-dir=web-nodejs \
+        --name=web
+```{{execute}}
+
+The **--context-dir** option specifies the sub-directly of the Git repository which contains 
+the source code for the application to be built and deployed. 
+
+A build gets created and starts building the Node.js Web UI container image. 

--- a/scenarios-3.9/microservice-nodejs/02-build-logs.md
+++ b/scenarios-3.9/microservice-nodejs/02-build-logs.md
@@ -1,0 +1,10 @@
+You can see the build logs using OpenShift Web Console 
+or OpenShift CLI, after a few moments when the build starts:
+
+```
+oc logs -f bc/web
+```{{execute}}
+
+The `-f` option is to follow the logs as the build progresses. After the building the Node.s Web UI 
+completes, it gets pushed into the internal image registry in OpenShift and then deployed within 
+your project.

--- a/scenarios-3.9/microservice-nodejs/03-verify.md
+++ b/scenarios-3.9/microservice-nodejs/03-verify.md
@@ -1,0 +1,18 @@
+In order to access the Web UI from outside (e.g. from a browser), it needs to get added to the load 
+balancer. Run the following command to add the Web UI service to the built-in HAProxy load balancer 
+in OpenShift.
+
+```
+oc expose svc/web
+```{{execute}}
+
+```
+oc get route web
+```{{execute}}
+
+Point your browser at the Web UI route url. You should be able to see the CoolStore with all 
+products and their inventory status.
+
+![CoolStore Shop](https://katacoda.com/openshift-roadshow/assets/coolstore-web.png)
+
+Well done! 

--- a/scenarios-3.9/microservice-nodejs/99-outro.md
+++ b/scenarios-3.9/microservice-nodejs/99-outro.md
@@ -1,0 +1,2 @@
+Now that you have all services deployed, move on to the next 
+scenario **Monitoring Application Health**.

--- a/scenarios-3.9/microservice-nodejs/index.json
+++ b/scenarios-3.9/microservice-nodejs/index.json
@@ -1,0 +1,44 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Web UI with Node.js and AngularJS",
+    "description": "",
+    "difficulty": "beginner",
+    "time": "5-10 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Deploy on OpenShift",
+                "text": "01-deploy.md"
+            },
+            {
+                "title": "View Build Logs",
+                "text": "02-build-logs.md"
+            }
+            ,
+            {
+                "title": "Web UI in Browser",
+                "text": "03-verify.md"
+            }
+        ],
+        "intro": {
+            "courseData": "run-init.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+          "text": "99-outro.md"
+        }
+    },
+    "environment": {
+        "uilayout": "terminal",
+        "hideintro": false,
+        "uisettings": "javascript",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/microservice-spring-boot/00-intro.md
+++ b/scenarios-3.9/microservice-spring-boot/00-intro.md
@@ -1,0 +1,13 @@
+In this scenario you will learn about Spring Boot and how you can build microservices 
+using Spring Boot and JBoss technologies. During this scenario, you will create a REST API for 
+the Catalog service in order to provide a list of products for the CoolStore online shop.
+
+## What is Spring Boot?
+
+[Spring Boot](https://projects.spring.io/spring-boot) is an opinionated framework that makes it easy to create stand-alone Spring based 
+applications with an embedded web containers such as Tomcat (or JBoss Web Server), Jetty and Undertowt 
+hat you can run directly on the JVM using **java -jar** Spring Boot also allows producing a war 
+file that can be deployed on stand-alone web containers.
+
+The opinionated approach means many choices about Spring platform and third-party libraries 
+are already made by Spring Boot so that you can get started with minimum effort and configuration.

--- a/scenarios-3.9/microservice-spring-boot/01-maven-project.md
+++ b/scenarios-3.9/microservice-spring-boot/01-maven-project.md
@@ -1,0 +1,18 @@
+The **catalog-spring-boot** project shows the components of 
+a Spring Boot project laid out in different subdirectories according to Maven best 
+practices. Run the following command to examine the Maven project structure.
+
+```
+tree
+```{{execute}}
+
+This is a minimal Spring Boot project with support for RESTful services and Spring Data with JPA for connecting
+to a database. This project currently contains no code other than the main class, `CatalogApplication.java`
+which is there to bootstrap the Spring Boot application.
+
+Examine `CatalogApplication.java`
+
+The database is configured using the Spring application configuration file which is located at 
+**src/main/resources/application.properties**. Examine this file to see the database connection details 
+and note that an in-memory H2 database is used in this scenario for local development and will be replaced
+with a PostgreSQL database in the following scenarios. Be patient! More on that later.

--- a/scenarios-3.9/microservice-spring-boot/02-maven-build.md
+++ b/scenarios-3.9/microservice-spring-boot/02-maven-build.md
@@ -1,0 +1,23 @@
+You can use Maven to make sure the skeleton project builds successfully.
+
+> Make sure to run the **package** Maven goal and not **install** The latter would 
+> download a lot more dependencies and do things you don't need yet!
+
+```
+mvn package
+```{{execute}}
+
+You should see a **BUILD SUCCESS** in the build logs.
+
+Once built, the resulting **jar** is located in the **target/** directory:
+
+```
+ls target/*.jar
+```{{execute}}
+
+The listed jar archite, **catalog-1.0-SNAPSHOT.jar** is an uber-jar with all the dependencies required packaged in the **jar** to enable running the application with **java -jar**.
+
+Now that the project is ready, let's get coding and create a domain model, data repository, and a  
+RESTful endpoint to create the Catalog service:
+
+![Catalog RESTful Service](https://katacoda.com/openshift-roadshow/assets/springboot-catalog-arch.png)

--- a/scenarios-3.9/microservice-spring-boot/03-create-domain.md
+++ b/scenarios-3.9/microservice-spring-boot/03-create-domain.md
@@ -1,0 +1,71 @@
+Create a new Java class named `Product.java` in 
+`com.redhat.cloudnative.catalog` package with the following code:
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/catalog/Product.java" data-target="replace">
+package com.redhat.cloudnative.catalog;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "PRODUCT", uniqueConstraints = @UniqueConstraint(columnNames = "itemId"))
+public class Product implements Serializable {
+
+  @Id
+  private String itemId;
+
+  private String name;
+
+  private String description;
+
+  private double price;
+
+  public Product() {
+  }
+
+  public String getItemId() {
+    return itemId;
+  }
+
+  public void setItemId(String itemId) {
+    this.itemId = itemId;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public double getPrice() {
+    return price;
+  }
+
+  public void setPrice(double price) {
+    this.price = price;
+  }
+
+  @Override
+  public String toString() {
+    return "Product [itemId=" + itemId + ", name=" + name + ", price=" + price + "]";
+  }
+}
+</pre>
+
+Review the **Product** domain model and note the JPA annotations on this class. **@Entity** marks the
+class as a JPA entity, **@Table** customizes the table creation process by defining a table
+name and database constraint and **@Id** marks the primary key for the table

--- a/scenarios-3.9/microservice-spring-boot/04-create-data-repository.md
+++ b/scenarios-3.9/microservice-spring-boot/04-create-data-repository.md
@@ -1,0 +1,29 @@
+Spring Data repository abstraction simplifies dealing with data models in Spring applications by
+reducing the amount of boilerplate code required to implement data access layers for various
+persistence stores. [Repository and its sub-interfaces](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.core-concepts)
+are the central concept in Spring Data which is a marker interface to provide
+data manipulation functionality for the entity class that is being managed. When the application starts,
+Spring finds all interfaces marked as repositories and for each interface found, the infrastructure
+configures the required persistent technologies and provides an implementation for the repository interface.
+
+Create a new Java interface named `ProductRepository.java` in `com.redhat.cloudnative.catalog` package 
+and extend [CrudRepository](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html) interface in order to indicate to Spring that you want to expose a 
+complete set of methods to manipulate the entity.
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/catalog/ProductRepository.java" data-target="replace">
+package com.redhat.cloudnative.catalog;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ProductRepository extends CrudRepository&lt;Product, String&gt; {
+}
+</pre>
+
+Build and package the Catalog service using Maven to make sure there are no compilation errors:
+
+```
+mvn package
+```{{execute}}
+
+That's it! Now that you have a domain model and a repository to retrieve the domain mode, let's create a
+RESTful service that returns the list of products.

--- a/scenarios-3.9/microservice-spring-boot/05-create-rest.md
+++ b/scenarios-3.9/microservice-spring-boot/05-create-rest.md
@@ -1,0 +1,48 @@
+Spring Boot uses Spring Web MVC as the default RESTful stack in Spring applications. Create 
+a new Java class named `CatalogController.java` in `com.redhat.cloudnative.catalog` package with 
+the following content:
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/catalog/CatalogController.java" data-target="replace">
+package com.redhat.cloudnative.catalog;
+
+import java.util.List;
+import java.util.Spliterator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping(value = "/api/catalog")
+public class CatalogController {
+
+	@Autowired
+    private ProductRepository repository;
+
+    @ResponseBody
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public List&lt;Product&gt; getAll() {
+        Spliterator&lt;Product&gt; products = repository.findAll().spliterator();
+        return StreamSupport.stream(products, false).collect(Collectors.toList());
+    }
+}
+</pre>
+
+The above REST services defines an endpoint that is accessible via **HTTP GET** at **/api/catalog**.
+
+Notice the **repository** field on the controller class which is used to retrieve the list of products. Spring Boot
+automatically provides an implementation for **ProductRepository** at runtime and
+[injects it into the controller using the **@Autowire** annotation](https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-spring-beans-and-dependency-injection.html).
+
+Build and package the Catalog service using Maven.
+
+```
+mvn package
+```{{execute}}
+
+You should see a **BUILD SUCCESS** in the build logs.

--- a/scenarios-3.9/microservice-spring-boot/06-test-local.md
+++ b/scenarios-3.9/microservice-spring-boot/06-test-local.md
@@ -1,0 +1,22 @@
+Using Spring Boot maven plugin, you can conveniently run the application locally and test the endpoint.
+
+```
+mvn spring-boot:run
+```{{execute T1}}
+
+When you see **Started CatalogApplication** in the logs, you can access the 
+Catalog REST API. Let’s test it out using `curl` in a new terminal window:
+
+```
+curl http://localhost:9000/api/catalog
+```{{execute T2}}
+
+You should see a result like:
+
+```
+[{"itemId":"329299","name":"Red Fedora","desc":"Official Red Hat Fedora","price":34.99},...]
+```
+
+The REST API returned a JSON object representing the product list. Congratulations!
+
+Stop the service by pressing **CTRL-C** in the first terminal window.

--- a/scenarios-3.9/microservice-spring-boot/07-deploy.md
+++ b/scenarios-3.9/microservice-spring-boot/07-deploy.md
@@ -1,0 +1,22 @@
+It’s time to build and deploy Catalog service on OpenShift using [Source-to-Image (S2I)](https://docs.openshift.com/container-platform/3.7/architecture/core_concepts/builds_and_image_streams.html#source-build).
+
+To build and deploy the Catalog service on OpenShift using the **fabric8** maven plugin, run the following maven command:
+
+```
+mvn fabric8:deploy
+```{{execute T1}}
+
+During the deployment, you might see that Fabric8 Maven Plugin throws an `java.util.concurrent.RejectedExecutionException` 
+exception. This is due to [a bug](https://github.com/fabric8io/kubernetes-client/issues/1035) in one of Fabric8 Maven Plugin 
+dependencies which is being worked on right now and will be fixed soon. You can ignore this exception for now. The deployment 
+nevertheless succeeds.
+
+`fabric8:deploy` will cause the following to happen:
+
+* The Catalog uber-jar is built using Spring Boot
+* A container image is built on OpenShift containing the Catalog uber-jar and JDK
+* All necessary objects are created within the OpenShift project to deploy the Catalog service
+
+Once this completes, your project should be up and running. OpenShift runs the different components of 
+the project in one or more pods which are the unit of runtime deployment and consists of the running 
+containers for the project. 

--- a/scenarios-3.9/microservice-spring-boot/08-explore-resources.md
+++ b/scenarios-3.9/microservice-spring-boot/08-explore-resources.md
@@ -1,0 +1,41 @@
+Let's take a moment and review the OpenShift resources that are created for the Catalog REST API:
+
+* Build Config: **catalog-s2i** build config is the configuration for building the Catalog 
+container image from the catalog source code or JAR archive
+* Image Stream: **catalog** image stream is the virtual view of all catalog container 
+images built and pushed to the OpenShift integrated registry.
+* Deployment Config: **catalog** deployment config deploys and redeploys the Catalog container 
+image whenever a new Catalog container image becomes available
+* Service: **catalog** service is an internal load balancer which identifies a set of 
+pods (containers) in order to proxy the connections it receives to them. Backing pods can be 
+added to or removed from a service arbitrarily while the service remains consistently available, 
+enabling anything that depends on the service to refer to it at a consistent address (service name 
+or IP).
+* Route: **catalog** route registers the service on the built-in external load-balancer 
+and assigns a public DNS name to it so that it can be reached from outside OpenShift cluster.
+
+You can review the above resources in the OpenShift Web Console or using `oc describe` command:
+
+> **bc** is the short-form of **buildconfig** and can be interchangeably used instead of it with the 
+> OpenShift CLI. The same goes for **is** instead of **imagestream**, **dc** instead of **deploymentconfig**
+> and **svc** instead of **service**
+
+```
+oc describe bc catalog-s2i
+```{{execute T1}}
+
+```
+oc describe is catalog
+```{{execute T1}}
+
+```
+oc describe dc catalog
+```{{execute T1}}
+
+```
+oc describe svc catalog
+```{{execute T1}}
+
+```
+oc describe route catalog
+```{{execute T1}}

--- a/scenarios-3.9/microservice-spring-boot/09-verify.md
+++ b/scenarios-3.9/microservice-spring-boot/09-verify.md
@@ -1,0 +1,23 @@
+You can see the expose DNS url for the Catalog service in the OpenShift Web Console or using 
+OpenShift CLI:
+
+```
+oc get routes
+```{{execute T1}}
+
+Copy the route url for the Catalog service and verify the Catalog service works using `curl`
+
+> Replace `CATALOG-ROUTE-HOST` with the Catalog route host listed from your project.
+
+```curl http://CATALOG-ROUTE-HOST/api/catalog```
+
+You should see a JSON response like:
+```
+[{"itemId":"329299","name":"Red Fedora","desc":"Official Red Hat Fedora","price":34.99},...]
+```
+
+You can also click on **Dashboard** at the top of the terminal window to 
+open OpenShift Web Console and log in using your username and password to 
+see the Catalog service in the web console.
+
+Well done!

--- a/scenarios-3.9/microservice-spring-boot/99-outro.md
+++ b/scenarios-3.9/microservice-spring-boot/99-outro.md
@@ -1,0 +1,2 @@
+You are now ready to start building a reactive microservice using 
+Eclipse Vert.x. Start with **Reactive Microservices with Eclipse Vert.x**.

--- a/scenarios-3.9/microservice-spring-boot/index.json
+++ b/scenarios-3.9/microservice-spring-boot/index.json
@@ -1,0 +1,73 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Microservices with Spring Boot",
+    "description": "",
+    "difficulty": "intermediate",
+    "time": "10-20 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Explore Spring Boot Project",
+                "text": "01-maven-project.md"
+            },
+            {
+                "title": "Build Maven Project",
+                "text": "02-maven-build.md"
+            },
+            {
+                "title": "Create a Domain Model",
+                "text": "03-create-domain.md"
+            },
+            {
+                "title": "Create a Data Repository",
+                "text": "04-create-data-repository.md"
+            },
+            {
+                "title": "Create a RESTful Service",
+                "text": "05-create-rest.md"
+            },
+            {
+                "title": "Test Catalog Service",
+                "text": "06-test-local.md"
+            },
+            {
+                "title": "Deploy on OpenShift",
+                "text": "07-deploy.md"
+            },
+            {
+                "title": "Explore Created Resources",
+                "text": "08-explore-resources.md"
+            },
+            {
+                "title": "Verify on OpenShift",
+                "text": "09-verify.md"
+            }
+        ],
+        "intro": {
+            "code": "run-init.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+          "text": "99-outro.md"
+        }
+    },
+    "files": [
+      "./src/main/java/com/redhat/cloudnative/catalog/Product.java",
+      "./src/main/java/com/redhat/cloudnative/catalog/ProductRepository.java",
+      "./src/main/java/com/redhat/cloudnative/catalog/CatalogController.java"
+    ],
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideintro": false,
+        "uisettings": "java",
+        "uieditorpath": "/root/catalog-spring-boot",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/microservice-spring-boot/run-init.sh
+++ b/scenarios-3.9/microservice-spring-boot/run-init.sh
@@ -1,0 +1,1 @@
+cd catalog-spring-boot

--- a/scenarios-3.9/microservice-vertx/00-intro.md
+++ b/scenarios-3.9/microservice-vertx/00-intro.md
@@ -1,0 +1,19 @@
+In this scenario you will learn about Eclipse Vert.x and how you can 
+build microservices using reactive principles. During this scenario you will 
+create a scalable API Gateway that aggregates Catalog and Inventory APIs.
+
+## What is Eclipse Vert.x?
+
+[Eclipse Vert.x](http://vertx.io) is a toolkit for building reactive applications on the Java Virtual Machine (JVM). Vert.x does not 
+impose a specific framework or packaging model and can be used within your existing applications and frameworks 
+in order to add reactive functionality by just adding the Vert.x jar files to the application classpath.
+
+Vert.x enables building reactive systems as defined by [The Reactive Manifesto](http://www.reactivemanifesto.org) and build 
+services that are:
+
+* *Responsive*: to handle requests in a reasonable time
+* *Resilient*: to stay responsive in the face of failures
+* *Elastic*: to stay responsive under various loads and be able to scale up and down
+* *Message driven*: components interact using asynchronous message-passing
+
+Vert.x is designed to be event-driven and non-blocking. Events are delivered in an event loop that must never be blocked. Unlike traditional applications, Vert.x uses a very small number of threads responsible for dispatching the events to event handlers. If the event loop is blocked, the events won’t be delivered anymore and therefore the code needs to be mindful of this execution model.

--- a/scenarios-3.9/microservice-vertx/01-maven-project.md
+++ b/scenarios-3.9/microservice-vertx/01-maven-project.md
@@ -1,0 +1,18 @@
+The **gateway-vertx** project shows the components of 
+a Vert.x project laid out in different subdirectories according to Maven best 
+practices. Run the following command to examine the Maven project structure.
+
+```
+tree
+```{{execute T1}}
+
+This is a minimal Vert.x project with support for RESTful services. This project currently contains no code
+other than the main class, `GatewayVerticle.java` which is there to bootstrap the Vert.x application. Verticles
+are encapsulated parts of the application that can run completely independently and communicate with each other
+via the built-in event bus in Vert.x. Verticles get deployed and run by Vert.x in an event loop and therefore it 
+is important that the code in a Verticle does not block. This asynchronous architecture allows Vert.x applications 
+to easily scale and handle large amounts of throughput with few threads.All API calls in Vert.x by default are non-blocking and support this concurrency model.
+
+![Vert.x Event Loop](https://katacoda.com/openshift-roadshow/assets/vertx-event-loop.jpg)
+
+Although you can have multiple, there is currently only one empty Verticle created in the **gateway-vertx** project. 

--- a/scenarios-3.9/microservice-vertx/02-maven-build.md
+++ b/scenarios-3.9/microservice-vertx/02-maven-build.md
@@ -1,0 +1,21 @@
+You can use Maven to make sure the skeleton project builds successfully. 
+
+> Make sure to run the `package` Maven goal and not `install` The latter would 
+> download a lot more dependencies and do things you don't need yet!
+
+```
+mvn package
+```{{execute T1}}
+
+You should see a **BUILD SUCCESS** in the logs.
+
+Once built, the resulting jar archive is located in the `target/` directory:
+
+```
+ls target/*.jar
+```{{execute T1}}
+
+The listed jar archive, `gateway-1.0-SNAPSHOT.jar` is an uber-jar with all the 
+dependencies required packaged in the jar archive to enable running the application with `java -jar`.
+
+Now that the project is ready, let's get coding!

--- a/scenarios-3.9/microservice-vertx/03-create-verticle.md
+++ b/scenarios-3.9/microservice-vertx/03-create-verticle.md
@@ -1,0 +1,104 @@
+In the previous scenarios, you have created two RESTful services: Catalog and Inventory. Instead of the
+web front contacting each of these backend services, you can create an API Gateway which is an entry
+point for for the web front to access all backend services from a single place. This pattern is expectedly
+called [API Gateway](http://microservices.io/patterns/apigateway.html) and is a common practice in Microservices
+architecture.
+
+![API Gateway Pattern](https://katacoda.com/openshift-roadshow/assets/coolstore-arch.png)
+
+Replace the content of `src/main/java/com/redhat/cloudnative/gateway/GatewayVerticle.java` class with the following by clicking on *Copy to Editor*:
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/gateway/GatewayVerticle.java" data-target="replace">
+package com.redhat.cloudnative.gateway;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.rxjava.core.AbstractVerticle;
+import io.vertx.rxjava.ext.web.Router;
+import io.vertx.rxjava.ext.web.RoutingContext;
+import io.vertx.rxjava.ext.web.client.WebClient;
+import io.vertx.rxjava.ext.web.codec.BodyCodec;
+import io.vertx.rxjava.ext.web.handler.CorsHandler;
+import io.vertx.rxjava.servicediscovery.ServiceDiscovery;
+import io.vertx.rxjava.servicediscovery.types.HttpEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Single;
+
+public class GatewayVerticle extends AbstractVerticle {
+    private static final Logger LOG = LoggerFactory.getLogger(GatewayVerticle.class);
+
+    private WebClient catalog;
+    private WebClient inventory;
+
+    @Override
+    public void start() {
+        Router router = Router.router(vertx);
+        router.route().handler(CorsHandler.create("*").allowedMethod(HttpMethod.GET));
+        router.get("/health").handler(ctx -> ctx.response().end(new JsonObject().put("status", "UP").toString()));
+        router.get("/api/products").handler(this::products);
+
+        ServiceDiscovery.create(vertx, discovery -> {
+            // Catalog lookup
+            Single&lt;WebClient&gt; catalogDiscoveryRequest = HttpEndpoint.rxGetWebClient(discovery,
+                    rec -> rec.getName().equals("catalog"))
+                    .onErrorReturn(t -> WebClient.create(vertx, new WebClientOptions()
+                            .setDefaultHost(System.getProperty("catalog.api.host", "localhost"))
+                            .setDefaultPort(Integer.getInteger("catalog.api.port", 9000))));
+
+            // Inventory lookup
+            Single&lt;WebClient&gt; inventoryDiscoveryRequest = HttpEndpoint.rxGetWebClient(discovery,
+                    rec -> rec.getName().equals("inventory"))
+                    .onErrorReturn(t -> WebClient.create(vertx, new WebClientOptions()
+                            .setDefaultHost(System.getProperty("inventory.api.host", "localhost"))
+                            .setDefaultPort(Integer.getInteger("inventory.api.port", 9001))));
+
+            // Zip all 3 requests
+            Single.zip(catalogDiscoveryRequest, inventoryDiscoveryRequest, (c, i) -> {
+                // When everything is done
+                catalog = c;
+                inventory = i;
+                return vertx.createHttpServer()
+                    .requestHandler(router::accept)
+                    .listen(Integer.getInteger("http.port", 8080));
+            }).subscribe();
+        });
+    }
+
+    private void products(RoutingContext rc) {
+        // Retrieve catalog
+        catalog.get("/api/catalog").as(BodyCodec.jsonArray()).rxSend()
+            .map(resp -> {
+                if (resp.statusCode() != 200) {
+                    new RuntimeException("Invalid response from the catalog: " + resp.statusCode());
+                }
+                return resp.body();
+            })
+            .flatMap(products ->
+                // For each item from the catalog, invoke the inventory service
+                Observable.from(products)
+                    .cast(JsonObject.class)
+                    .flatMapSingle(product ->
+                        inventory.get("/api/inventory/" + product.getString("itemId")).as(BodyCodec.jsonObject())
+                            .rxSend()
+                            .map(resp -> {
+                                if (resp.statusCode() != 200) {
+                                    LOG.warn("Inventory error for {}: status code {}",
+                                            product.getString("itemId"), resp.statusCode());
+                                    return product.copy();
+                                }
+                                return product.copy().put("availability",
+                                    new JsonObject().put("quantity", resp.body().getInteger("quantity")));
+                            }))
+                    .toList().toSingle()
+            )
+            .subscribe(
+                list -> rc.response().end(Json.encodePrettily(list)),
+                error -> rc.response().end(new JsonObject().put("error", error.getMessage()).toString())
+            );
+    }
+}
+</pre>

--- a/scenarios-3.9/microservice-vertx/04-explore-verticle.md
+++ b/scenarios-3.9/microservice-vertx/04-explore-verticle.md
@@ -1,0 +1,31 @@
+Let's break down what happens in the above code. The `start()` method creates an HTTP
+server and a REST mapping to map `/api/products` to the `products()` Java
+method.
+
+Vert.x provides [built-in service discovery](http://vertx.io/docs/vertx-service-discovery/java)
+for finding where dependent services are deployed
+and accessing their endpoints. Vert.x service discovery can seamlessly integrated with external
+service discovery mechanisms provided by OpenShift, Kubernetes, Consul, Redis, etc.
+
+In this scenario, since you will deploy the API Gateway on OpenShift, the OpenShift service discovery
+bridge is used to automatically import OpenShift services into the Vert.x application as they
+get deployed and undeployed. Since you also want to test the API Gateway locally, there is an
+`onErrorReturn()` clause in the the service lookup to fallback on a local service for Inventory
+and Catalog REST APIs.
+
+The `products()` method invokes the Catalog REST endpoint and retrieves the products. It then
+iterates over the retrieve products and for each product invokes the
+Inventory REST endpoint to get the inventory status and enrich the product data with availability
+info.
+
+Note that instead of making blocking calls to the Catalog and Inventory REST APIs, all calls
+are non-blocking and handled using [RxJava](http://vertx.io/docs/vertx-rx/java). Due to its non-blocking
+nature, the `product()` method can immediately return without waiting for the Catalog and Inventory
+REST invocations to complete and whenever the result of the REST calls is ready, the result
+will be acted upon and update the response which is then sent back to the client.
+
+Run the maven build to make sure the code compiles successfully.
+
+```
+mvn package
+```{{execute}}

--- a/scenarios-3.9/microservice-vertx/05-test-start-services.md
+++ b/scenarios-3.9/microservice-vertx/05-test-start-services.md
@@ -1,0 +1,16 @@
+Since the API Gateway requires the Catalog and Inventory services to be running, let's run all three 
+services simultaneously and verify that the API Gateway works as expected. 
+
+Start the Catalog service in a new terminal:
+
+```
+cd catalog-spring-boot
+mvn spring-boot:run
+```{{execute T2}}
+
+Start the Inventory service as well in another new terminal:
+
+```
+cd inventory-wildfly-swarm
+mvn wildfly-swarm:run
+```{{execute T3}}

--- a/scenarios-3.9/microservice-vertx/06-test-local.md
+++ b/scenarios-3.9/microservice-vertx/06-test-local.md
@@ -1,0 +1,41 @@
+Now that Catalog and Inventory services are up and running, start the API Gateway 
+service in the first terminal window:
+
+```
+mvn vertx:run
+```{{execute T1}}
+
+You will see the following exception in the logs: 
+`java.io.FileNotFoundException: .../kubernetes.io/serviceaccount/token` which is 
+expected. It is the result of Vert.x trying to import services form OpenShift. Since you are 
+running the API Gateway on your local machine, the lookup fails and falls back to the local 
+service lookup.
+
+Note that while the application is running using `mvn vertx:run`, you can make changes in the code
+and they would immediately be compiled and updated in the running application to provide fast
+feedback to the developer.
+
+Now you can test the API Gateway by hitting the `/api/products` endpoint using `curl` in 
+a new terminal window:
+
+```
+curl http://localhost:8080/api/products
+```{{execute T4}}
+
+You should see a JSON response like:
+```
+[{
+  "itemId" : "329299",
+  "name" : "Red Fedora",
+  "desc" : "Official Red Hat Fedora",
+  "price" : 34.99,
+  "availability" : {
+    "quantity" : 35
+  }
+...
+```
+
+Note that the JSON response aggregates responses fro Catalog and Inventory services and 
+the inventory info for each product is available within the same JSON object.
+
+Stop all services by pressing **CTRL-C** in all terminal windows.

--- a/scenarios-3.9/microservice-vertx/07-deploy.md
+++ b/scenarios-3.9/microservice-vertx/07-deploy.md
@@ -1,0 +1,38 @@
+It’s time to build and deploy our service on OpenShift. 
+Like discussed, Vert.x service discovery integrates into OpenShift service discovery via OpenShift 
+REST API and imports available services to make them available to the Vert.x application. Security 
+in OpenShift comes first and therefore accessing the OpenShift REST API requires the user or the 
+system (Vert.x in this case) to have sufficient permissions to do so. All containers in 
+OpenShift run with a **serviceaccount** (by default, the project **default** service account) which can 
+be used to grant permissions for operations like accessing the OpenShift REST API. You can read 
+more about service accounts in the [OpenShift Documentation](https://docs.openshift.com/container-platform/3.7/dev_guide/service_accounts.html) and this 
+[blog post](https://blog.openshift.com/understanding-service-accounts-sccs/#_service_accounts)
+
+Grant permission to the API Gateway to be able to access OpenShift REST API and discover services.
+
+```
+oc policy add-role-to-user view -n coolstore -z default
+```{{execute T1}}
+
+It’s time to build and deploy API Gateway service on OpenShift using [Source-to-Image (S2I)](https://docs.openshift.com/container-platform/3.7/architecture/core_concepts/builds_and_image_streams.html#source-build).
+To build and deploy the Inventory service on OpenShift using the fabric8 maven plugin, 
+run the following Maven command __in the first terminal window__:
+
+```
+mvn fabric8:deploy
+```{{execute T1}}
+
+During the deployment, you might see that Fabric8 Maven Plugin throws an `java.util.concurrent.RejectedExecutionException` 
+exception. This is due to [a bug](https://github.com/fabric8io/kubernetes-client/issues/1035) in one of Fabric8 Maven Plugin 
+dependencies which is being worked on right now and will be fixed soon. You can ignore this exception for now. The deployment 
+nevertheless succeeds.
+
+`fabric8:deploy` will cause the following to happen:
+
+* The API Gateway uber-jar is built using Vert.x 
+* A container image is built on OpenShift containing the API Gateway uber-jar and JDK
+* All necessary objects are created within the OpenShift project to deploy the API Gateway service
+
+Once this completes, your project should be up and running. OpenShift runs the different components of 
+the project in one or more pods which are the unit of runtime deployment and consists of the running 
+containers for the project. 

--- a/scenarios-3.9/microservice-vertx/08-explore-resources.md
+++ b/scenarios-3.9/microservice-vertx/08-explore-resources.md
@@ -1,0 +1,41 @@
+Let's take a moment and review the OpenShift resources that are created for the API Gateway:
+
+* Build Config: **gateway-s2i** build config is the configuration for building the Gateway 
+container image from the gateway source code or JAR archive
+* Image Stream: **gateway** image stream is the virtual view of all gateway container 
+images built and pushed to the OpenShift integrated registry.
+* Deployment Config: **gateway** deployment config deploys and redeploys the Gateway container 
+image whenever a new Gateway container image becomes available
+* Service: **gateway** service is an internal load balancer which identifies a set of 
+pods (containers) in order to proxy the connections it receives to them. Backing pods can be 
+added to or removed from a service arbitrarily while the service remains consistently available, 
+enabling anything that depends on the service to refer to it at a consistent address (service name 
+or IP).
+* Route: **gateway** route registers the service on the built-in external load-balancer 
+and assigns a public DNS name to it so that it can be reached from outside OpenShift cluster.
+
+You can review the above resources in the OpenShift Web Console or using `oc describe` command:
+
+> **bc** is the short-form of **buildconfig** and can be interchangeably used instead of it with the
+> OpenShift CLI. The same goes for **is** instead of **imagestream**, **dc** instead of **deploymentconfig**
+> and **svc** instead of **service**
+
+```
+oc describe bc gateway-s2i
+```{{execute}}
+
+```
+oc describe is gateway
+```{{execute}}
+
+```
+oc describe dc gateway
+```{{execute}}
+
+```
+oc describe svc gateway
+```{{execute}}
+
+```
+oc describe route gateway
+```{{execute}}

--- a/scenarios-3.9/microservice-vertx/09-verify.md
+++ b/scenarios-3.9/microservice-vertx/09-verify.md
@@ -1,0 +1,31 @@
+You can see the expose DNS url for the API Gateway service in the OpenShift Web Console or using 
+OpenShift CLI.
+
+```
+oc get routes
+```{{execute}}
+
+Copy the route url for API Gateway and verify the API Gateway service works using `curl`
+
+> Replace **API-GATEWAY-ROUTE-HOST** with your API Gateway route url in the following command
+
+```curl http://API-GATEWAY-ROUTE-HOST/api/products```
+
+You would see a JSON response like:
+
+```
+[{
+  "itemId" : "329299",
+  "name" : "Red Fedora",
+  "desc" : "Official Red Hat Fedora",
+  "price" : 34.99,
+  "availability" : {
+    "quantity" : 35
+  }
+...
+```
+
+As mentioned earlier, Vert.x built-in service discovery is integrated with OpenShift service 
+discovery to lookup the Catalog and Inventory APIs.
+
+Well done! 

--- a/scenarios-3.9/microservice-vertx/99-outro.md
+++ b/scenarios-3.9/microservice-vertx/99-outro.md
@@ -1,0 +1,2 @@
+Move on to the next scenario, **Web UI with Node.js and AngularJS**, to add a font-end 
+to the microservices you have built so far.

--- a/scenarios-3.9/microservice-vertx/index.json
+++ b/scenarios-3.9/microservice-vertx/index.json
@@ -1,0 +1,71 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Reactive Microservices with Eclipse Vert.x",
+    "description": "",
+    "difficulty": "intermediate",
+    "time": "10-20 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Explore Vert.x Project",
+                "text": "01-maven-project.md"
+            },
+            {
+                "title": "Build Maven Project",
+                "text": "02-maven-build.md"
+            },
+            {
+                "title": "Create an API Gateway",
+                "text": "03-create-verticle.md"
+            },
+            {
+                "title": "Examine the Gateway Verticle",
+                "text": "04-explore-verticle.md"
+            },
+            {
+                "title": "Start Inventory and Catalog",
+                "text": "05-test-start-services.md"
+            },
+            {
+                "title": "Test API Gateway",
+                "text": "06-test-local.md"
+            },
+            {
+                "title": "Deploy on OpenShift",
+                "text": "07-deploy.md"
+            },
+            {
+                "title": "Explore Created Resources",
+                "text": "08-explore-resources.md"
+            },
+            {
+                "title": "Verify on OpenShift",
+                "text": "09-verify.md"
+            }
+        ],
+        "intro": {
+            "code": "run-init.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+          "text": "99-outro.md"
+        }
+    },
+    "files": [
+      "./src/main/java/com/redhat/cloudnative/gateway/GatewayVerticle.java"
+    ],
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideintro": false,
+        "uisettings": "java",
+        "uieditorpath": "/root/gateway-vertx",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/microservice-vertx/run-init.sh
+++ b/scenarios-3.9/microservice-vertx/run-init.sh
@@ -1,0 +1,1 @@
+cd gateway-vertx

--- a/scenarios-3.9/microservice-wildfly-swarm/00-intro.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/00-intro.md
@@ -1,0 +1,22 @@
+In this scenario you will learn about building microservices using WildFly Swarm.
+
+## What is WildFly Swarm?
+
+Java EE applications are traditionally created as an **ear** or **war** archive including all 
+dependencies and deployed in an application server. Multiple Java EE applications can and 
+were typically deployed in the same application server. This model is well understood in 
+the development teams and has been used over the past several years.
+
+[WildFly Swarm](http://wildfly-swarm.io) offers an innovative approach to packaging and 
+running Java EE applications by 
+packaging them with just enough of the Java EE server runtime to be able to run them directly 
+on the JVM using **java -jar** For more details on various approaches to packaging Java 
+applications, read [this blog post](https://developers.redhat.com/blog/2017/08/24/the-skinny-on-fat-thin-hollow-and-uber).
+
+WildFly Swarm is based on WildFly and it's compatible with 
+MicroProfile, which is a community effort to standardized the subset of Java EE standards 
+such as JAX-RS, CDI and JSON-P that are useful for building microservices applications.
+
+Since WildFly Swarm is based on Java EE standards, it significantly simplifies refactoring 
+existing Java EE application to microservices and allows much of existing code-base to be 
+reused in the new services.

--- a/scenarios-3.9/microservice-wildfly-swarm/01-maven-project.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/01-maven-project.md
@@ -1,0 +1,18 @@
+The **inventory-wildfly-swarm** project shows the components of 
+a WildFly Swarm project laid out in different subdirectories according to Maven best 
+practices. Run the following command to examine the Maven project structure.
+
+```
+tree
+```{{execute}}
+
+This is a minimal Java EE project with support for JAX-RS for building 
+RESTful services and JPA for connecting
+to a database. [JAX-RS](https://docs.oracle.com/javaee/7/tutorial/jaxrs.htm) 
+is one of Java EE standards that uses Java annotations 
+to simplify the development of RESTful web services. [Java Persistence API (JPA)](https://docs.oracle.com/javaee/7/tutorial/partpersist.htm) is 
+another Java EE standard that provides Java developers with an 
+object/relational mapping facility for managing relational data in Java applications.
+
+This project currently contains no code other than the main class for exposing a single 
+RESTful application defined in `InventoryApplication.java`.

--- a/scenarios-3.9/microservice-wildfly-swarm/02-maven-build.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/02-maven-build.md
@@ -1,0 +1,26 @@
+Run the Maven build to make sure the skeleton project builds successfully. You 
+should get a **BUILD SUCCESS** message in the logs, otherwise the build has failed.
+
+> Make sure to run the **package** Maven goal and not **install**. The latter would 
+> download a lot more dependencies and do things you don't need yet!
+
+```
+mvn package
+```{{execute}}
+
+You should see a **BUILD SUCCESS** in the logs.
+
+Once built, the resulting *jar* is located in the **target** directory:
+
+```
+ls target/*.jar
+```{{execute}}
+
+The listed jar archive, **inventory-1.0-SNAPSHOT-swarm.jar** , is an uber-jar with 
+all the dependencies required packaged in the *jar* to enable running the 
+application with **java -jar**. WildFly Swarm also creates a *war* packaging as a standard Java EE web app 
+that could be deployed to any Java EE app server (for example, JBoss EAP, or its upstream WildFly project). 
+
+Now let's write some code and create a domain model and a RESTful endpoint to create the Inventory service:
+
+![Inventory RESTful Service](https://katacoda.com/openshift-roadshow/assets/wfswarm-inventory-arch.png)

--- a/scenarios-3.9/microservice-wildfly-swarm/03-create-domain.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/03-create-domain.md
@@ -1,0 +1,84 @@
+Create a new Java class named `Inventory.java` in 
+`com.redhat.cloudnative.inventory` package with the following code.
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/inventory/Inventory.java" data-target="replace">
+package com.redhat.cloudnative.inventory;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "INVENTORY", uniqueConstraints = @UniqueConstraint(columnNames = "itemId"))
+public class Inventory implements Serializable {
+	@Id
+    private String itemId;
+
+    private int quantity;
+
+    public Inventory() {
+    }
+
+    public String getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(String itemId) {
+        this.itemId = itemId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    @Override
+    public String toString() {
+        return "Inventory [itemId='" + itemId + '\'' + ", quantity=" + quantity + ']';
+    }
+}
+</pre>
+
+Review the **Inventory** domain model and note the JPA annotations on this class. **@Entity** marks
+the class as a JPA entity, **@Table** customizes the table creation process by defining a table
+name and database constraint and **@Id** marks the primary key for the table.
+
+WildFly Swarm configuration is done to a large extend through detecting the intent of the
+developer and automatically adding the required dependencies configurations to make sure it can
+get out of the way and developers can be productive with their code rather than Googling for
+configuration snippets. As an example, configuration database access with JPA is composed of
+the following steps:
+
+1. Adding the `org.wildfly.swarm:jpa` dependency to **pom.xml**
+2. Adding the database driver (e.g. `org.postgresql:postgresql`) to ** pom.xml**
+3. Adding database connection details in **src/main/resources/project-stages.yml**
+
+Examine **pom.xml** and note the `org.wildfly.swarm:jpa` that is already added to enable JPA:
+
+```xml
+<dependency>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>jpa</artifactId>
+</dependency>
+```
+
+Examine **src/main/resources/META-INF/persistence.xml** to see the JPA datasource configuration
+for this project. Also note that the configurations uses **META-INF/load.sql** to import
+initial data into the database.
+
+Examine **src/main/resources/project-stages.yml** to see the database connection details.
+An in-memory H2 database is used in this scenario for local development and in the following
+labs will be replaced with a PostgreSQL database. Be patient! More on that later.
+
+Build and package the Inventory service using Maven to make sure you code compiles:
+
+```
+mvn package
+```{{execute}}
+
+If builds successfully, continue to the next step to create a RESTful service.

--- a/scenarios-3.9/microservice-wildfly-swarm/04-create-rest.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/04-create-rest.md
@@ -1,0 +1,39 @@
+WildFly Swarm uses JAX-RS standard for building REST services. Create a new Java class named
+`InventoryResource.java` in `com.redhat.cloudnative.inventory` package with the following
+content by clicking on *Copy to Editor*:
+
+<pre class="file" data-filename="./src/main/java/com/redhat/cloudnative/inventory/InventoryResource.java" data-target="replace">
+package com.redhat.cloudnative.inventory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.persistence.*;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+@ApplicationScoped
+public class InventoryResource {
+    @PersistenceContext(unitName = "InventoryPU")
+    private EntityManager em;
+
+    @GET
+    @Path("/api/inventory/{itemId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Inventory getAvailability(@PathParam("itemId") String itemId) {
+        Inventory inventory = em.find(Inventory.class, itemId);
+        return inventory;
+    }
+}
+</pre>
+
+The above REST services defines an endpoint that is accessible via **HTTP GET** at
+for example **/api/inventory/329299** with
+the last path param being the product id which we want to check its inventory status.
+
+Build and package the Inventory service using Maven
+
+```
+mvn package
+```{{execute}}
+
+You should see a **BUILD SUCCESS** in the build logs.

--- a/scenarios-3.9/microservice-wildfly-swarm/05-test-local.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/05-test-local.md
@@ -1,0 +1,30 @@
+Using WildFly Swarm maven plugin, you can conveniently run the application locally and test the endpoint.
+
+```
+mvn wildfly-swarm:run
+```{{execute}}
+
+Alternatively, you can run the application using the uber-jar produced 
+during the Maven build: 
+
+```java -jar target/inventory-1.0-SNAPSHOT-swarm.jar```
+
+Once you see **WildFly Swarm is Ready** in the logs, the Inventory service is up and running and you can access the 
+inventory REST API. Let’s test it out using `curl` in a new terminal window. 
+
+You can open an new terminal window by clicking on the plus (+) icon on the terminal toolbar and then 
+choose **Open New Terminal**. You can also click on the following command to automatically open a new 
+terminal:
+
+```
+curl http://localhost:9001/api/inventory/329299
+```{{execute T2}}
+
+You would see a JSON response like this:
+```
+{"itemId":"329299","quantity":35}
+```
+
+The REST API returned a JSON object representing the inventory count for this product. Congratulations!
+
+Stop the service by pressing **CTRL-C** in the first terminal window.

--- a/scenarios-3.9/microservice-wildfly-swarm/06-s2i.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/06-s2i.md
@@ -1,0 +1,12 @@
+It’s time to build and deploy our service on OpenShift. 
+OpenShift [Source-to-Image (S2I)](https://docs.openshift.com/container-platform/3.7/architecture/core_concepts/builds_and_image_streams.html#source-build) 
+feature can be used to build a container image from your project. OpenShift 
+S2I uses the [supported OpenJDK container image](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift) to build the final container image of the 
+Inventory service by uploading the WildFly Swam uber-jar from the **target** folder to 
+the OpenShift platform. 
+
+Maven projects can use the [Fabric8 Maven Plugin](https://maven.fabric8.io) in order 
+to use OpenShift S2I for building 
+the container image of the application from within the project. This maven plugin is a Kubernetes/OpenShift client 
+able to communicate with the OpenShift platform using the REST endpoints in order to issue the commands 
+allowing to build a project, deploy it and finally launch a docker process as a pod.

--- a/scenarios-3.9/microservice-wildfly-swarm/07-deploy.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/07-deploy.md
@@ -1,0 +1,21 @@
+To build and deploy the Inventory service on OpenShift using the **fabric8** maven plugin, run the following Maven command:
+
+```
+mvn fabric8:deploy
+```{{execute T1}}
+
+During the deployment, you might see that Fabric8 Maven Plugin throws an `java.util.concurrent.RejectedExecutionException` 
+exception. This is due to [a bug](https://github.com/fabric8io/kubernetes-client/issues/1035) in one of Fabric8 Maven Plugin 
+dependencies which is being worked on right now and will be fixed soon. You can ignore this exception for now. The deployment 
+nevertheless succeeds.
+
+`fabric8:deploy` will cause the following to happen:
+
+* The Inventory uber-jar is built using WildFly Swarm
+* A container image is built on OpenShift containing the Inventory uber-jar and JDK
+* All necessary objects are created within the OpenShift project to deploy the Inventory service
+
+This might take little while depending on the network bandwidth but once this completes, your 
+project should be up and running. OpenShift runs the different components of 
+the project in one or more pods which are the unit of runtime deployment and consists of the running 
+containers for the project. 

--- a/scenarios-3.9/microservice-wildfly-swarm/08-explore-resources.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/08-explore-resources.md
@@ -1,0 +1,42 @@
+Let's take a moment and review the OpenShift resources that are created for the Inventory REST API:
+
+* Build Config: **inventory-s2i** build config is the configuration for building the Inventory 
+container image from the inventory source code or JAR archive
+* Image Stream: **inventory** image stream is the virtual view of all inventory container 
+images built and pushed to the OpenShift integrated registry.
+* Deployment Config: **inventory** deployment config deploys and redeploys the Inventory container 
+image whenever a new Inventory container image becomes available
+* Service: **inventory** service is an internal load balancer which identifies a set of 
+pods (containers) in order to proxy the connections it receives to them. Backing pods can be 
+added to or removed from a service arbitrarily while the service remains consistently available, 
+enabling anything that depends on the service to refer to it at a consistent address (service name 
+or IP).
+* Route: **inventory** route registers the service on the built-in external load-balancer 
+and assigns a public DNS name to it so that it can be reached from outside OpenShift cluster.
+
+You can review the above resources in the OpenShift Web Console or using `oc describe` command:
+
+> **bc** is the short-form of **buildconfig** and can be interchangeably used 
+> instead of it with the OpenShift CLI. The same goes for **is** instead 
+> of **imagestream**, **dc** instead of **deploymentconfig** and **svc** instead of **service**.
+
+
+```
+oc describe bc inventory-s2i
+```{{execute T1}}
+
+```
+oc describe is inventory
+```{{execute T1}}
+
+```
+oc describe dc inventory
+```{{execute T1}}
+
+```
+oc describe svc inventory
+```{{execute T1}}
+
+```
+oc describe route inventory
+```{{execute T1}}

--- a/scenarios-3.9/microservice-wildfly-swarm/09-verify.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/09-verify.md
@@ -1,0 +1,23 @@
+You can see the expose DNS url for the Inventory service in the OpenShift Web Console or using 
+OpenShift CLI:
+
+```
+oc get routes
+```{{execute T1}}
+
+Copy the route url for the Inventory service and verify the API Gateway service 
+works using `curl`, replace `INVENTORY-ROUTE-HOST` with your route url:
+
+```curl http://INVENTORY-ROUTE-HOST/api/inventory/329299```
+
+You should see a JSON response like:
+
+```
+{"itemId":"329299","quantity":35}
+```
+
+You can also click on **Dashboard** at the top of the terminal window to 
+open OpenShift Web Console and log in using your username and password to 
+see the Inventory service in the web console.
+
+Well done!

--- a/scenarios-3.9/microservice-wildfly-swarm/99-outro.md
+++ b/scenarios-3.9/microservice-wildfly-swarm/99-outro.md
@@ -1,0 +1,2 @@
+You are now ready to start building a microservice using Spring 
+Boot. Start with **Microservices with Spring Boot**.

--- a/scenarios-3.9/microservice-wildfly-swarm/index.json
+++ b/scenarios-3.9/microservice-wildfly-swarm/index.json
@@ -1,0 +1,73 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Enterprise Microservices with WildFly Swarm",
+    "description": "",
+    "difficulty": "intermediate",
+    "time": "10-20 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Explore WildFly Swarm Project",
+                "text": "01-maven-project.md"
+            },
+            {
+                "title": "Build Maven Project",
+                "text": "02-maven-build.md"
+            },
+            {
+                "title": "Create a Domain Model",
+                "text": "03-create-domain.md"
+            },
+            {
+                "title": "Create a RESTful Service",
+                "text": "04-create-rest.md"
+            },
+            {
+                "title": "Testing Inventory Service",
+                "text": "05-test-local.md"
+            },
+            {
+                "title": "Source-to-Image",
+                "text": "06-s2i.md"
+            },
+            {
+                "title": "Deploy on OpenShift",
+                "text": "07-deploy.md"
+            },
+            {
+                "title": "Explore Created Resources",
+                "text": "08-explore-resources.md"
+            },
+            {
+                "title": "Verify on OpenShift",
+                "text": "09-verify.md"
+            }
+
+        ],
+        "intro": {
+            "code": "run-init.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+          "text": "99-outro.md"
+        }
+    },
+    "files": [
+      "./src/main/java/com/redhat/cloudnative/inventory/Inventory.java",
+      "./src/main/java/com/redhat/cloudnative/inventory/InventoryResource.java"
+    ],
+    "environment": {
+        "uilayout": "editor-terminal",
+        "hideintro": false,
+        "uisettings": "java",
+        "uieditorpath": "/root/inventory-wildfly-swarm",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/scenarios-3.9/microservice-wildfly-swarm/run-init.sh
+++ b/scenarios-3.9/microservice-wildfly-swarm/run-init.sh
@@ -1,0 +1,1 @@
+cd inventory-wildfly-swarm

--- a/scenarios-3.9/monitor-health/00-intro.md
+++ b/scenarios-3.9/monitor-health/00-intro.md
@@ -1,0 +1,6 @@
+When building microservices, monitoring becomes of extreme importance to make sure all services 
+are running at all times, and when they don't there are automatic actions triggered to rectify 
+the issues. 
+
+In this scenario we will learn how to monitor application health using OpenShift 
+health probes and how you can see container resource consumption using metrics.

--- a/scenarios-3.9/monitor-health/01-health-probes.md
+++ b/scenarios-3.9/monitor-health/01-health-probes.md
@@ -1,0 +1,24 @@
+OpenShift, using Kubernetes health probes, offers a solution for monitoring application 
+health and try to automatically heal faulty containers through restarting them to fix issues such as
+a deadlock in the application which can be resolved by restarting the container. Restarting a container 
+in such a state can help to make the application more available despite bugs.
+
+Furthermore, there are of course a category of issues that can't be resolved by restarting the container. 
+In those scenarios, OpenShift would remove the faulty container from the built-in load-balancer and send traffic 
+only to the healthy container remained.
+
+There are two type of health probes available in OpenShift: [liveness probes and readiness probes](https://docs.openshift.com/container-platform/3.7/dev_guide/application_health.html#container-health-checks-using-probes). 
+*Liveness probes* are to know when to restart a container and *readiness probes* to know when a 
+Container is ready to start accepting traffic.
+
+Health probes also provide crucial benefits when automating deployments with practices like rolling updates in 
+order to remove downtime during deployments. A readiness health probe would signal OpenShift when to switch 
+traffic from the old version of the container to the new version so that the users don't get affected during 
+deployments.
+
+There are [three ways to define a health probe](https://docs.openshift.com/container-platform/3.7/dev_guide/application_health.html#container-health-checks-using-probes) for a container:
+
+* **HTTP Checks:** check the response code of an HTTP endpoint. 
+* **Container Execution Checks:** check the return value of a command inside the container
+* **TCP Socket Checks:** check connectivity to a port on the container
+ 

--- a/scenarios-3.9/monitor-health/02-explore-endpoints.md
+++ b/scenarios-3.9/monitor-health/02-explore-endpoints.md
@@ -1,0 +1,64 @@
+Spring Boot, WildFly Swarm and Vert.x all provide out-of-the-box support for creating RESTful endpoints that
+provide details on the health of the application. These endpoints by default provide basic data about the 
+service however they all provide a way to customize the health data and add more meaningful information (e.g. 
+database connection health, backoffice system availability, etc).
+
+[Spring Boot Actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready) is a 
+sub-project of Spring Boot which adds health and management HTTP endpoints to the application. Enabling Spring Boot 
+Actuator is done via adding `spring-boot-starter-actuator` dependency to the Maven project 
+dependencies which is already done for the Catalog services.
+
+Verify that the health endpoint works for the Catalog service using `curl` replacing `CATALOG-ROUTE-HOST`
+with the Catalog route url:
+
+> Find out route urls by `oc get route`
+
+```
+curl http://CATALOG-ROUTE-HOST/health
+```
+
+You should see a response like:
+
+```
+{"status":"UP", ...}
+```
+
+[WildFly Swarm health endpoints](https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/content/advanced/monitoring.html) function in a similar fashion and are enabled by adding WildFly Swarm `monitor`
+to the Maven project dependencies. 
+This is also already done for the Inventory service.
+
+Verify that the health endpoint works for the Inventory service using `curl` replacing `INVENTORY-ROUTE-HOST`
+with the Catalog route url:
+
+```
+curl http://INVENTORY-ROUTE-HOST/node
+```
+
+You should see a response like:
+
+```
+{
+    ...
+    "server-state" : "running",
+    ...
+}
+```
+
+Expectedly, Eclipse Vert.x also provides a [health check module](http://vertx.io/docs/vertx-health-check/java) 
+which is enabled by adding `vertx-health-check` as a dependency to the Maven project. 
+
+Verify that the health endpoint works for the Inventory service using `curl` 
+replacing `API-GATEWAY-ROUTE-HOST` with the API Gateway route url:
+
+```
+curl http://API-GATEWAY-ROUTE-HOST/health
+```
+
+You should see a response like:
+
+```
+{"status":"UP"}
+```
+
+Last but not least, although you can build more sophisticated health endpoints for the Web UI as well, you 
+can use the root context of the Web UI in this scenario to verify it's up and running.

--- a/scenarios-3.9/monitor-health/03-add-probe-catalog.md
+++ b/scenarios-3.9/monitor-health/03-add-probe-catalog.md
@@ -1,0 +1,33 @@
+Health probes are defined on the deployment config (`dc`) and can be added using OpenShift Web 
+Console or OpenShift CLI. 
+
+Add a liveness probe on the Catalog deployment config:
+
+```
+oc set probe dc/catalog --liveness --get-url=http://:8080/health
+```{{execute}}
+
+OpenShift automates deployments using [deployment triggers](https://docs.openshift.com/container-platform/3.7/dev_guide/deployments/basic_deployment_operations.html#triggers) 
+that react to changes to the container image or configuration. 
+Therefore, as soon as you define the probe, OpenShift automatically redeploys the 
+Catalog pod using the new configuration including the liveness probe. 
+
+The `--get-url` defines the HTTP endpoint to use for check the liveness of the container. The `ht<span>tp://:8080`
+syntax is a convenient way to define the endpoint without having to worry about the hostname for the running 
+container. 
+
+Add a readiness probe on the catalog deployment config using the same `/health` endpoint that you used for 
+the liveness probe. Note that it's recommended to have separate endpoints for readiness and liveness.
+
+```
+oc set probe dc/catalog --readiness --get-url=http://:8080/health
+```{{execute}}
+
+Viola! OpenShift automatically restarts the Catalog pod and as soon as the health 
+probes succeed, it is ready to receive traffic. 
+
+Fabric8 Maven Plugin can also be configured to automatically set the health 
+probes when running `fabric8:deploy` goal. Read more on Fabric8 docs for 
+[Spring Boot](https://maven.fabric8.io/#f8-spring-boot-health-check), 
+[WildFly Swarm](https://maven.fabric8.io/#f8-wildfly-swarm-health-check) and 
+[Eclipse Vert.x](https://maven.fabric8.io/#f8-vertx-health-check).

--- a/scenarios-3.9/monitor-health/04-add-probe-inventory.md
+++ b/scenarios-3.9/monitor-health/04-add-probe-inventory.md
@@ -1,0 +1,21 @@
+Adding liveness and readiness probes can be done at the same time if you want to define the same health endpoint 
+and parameters for both liveness and readiness probes. 
+
+Add liveness and readiness probes to the Inventory service:
+
+```
+oc set probe dc/inventory \
+    --liveness \
+    --readiness \
+    --get-url=http://:8080/node
+```{{execute}}
+
+OpenShift automatically restarts the Inventory pod and as soon as the health probes succeed, it is ready to receive traffic. 
+
+You can get a detailed look into the deployment config and verify that the health probes are in fact configured as you wanted:
+
+```
+oc describe dc/inventory
+```{{execute}}
+
+Look for `Liveness` and `Readiness` in the result.

--- a/scenarios-3.9/monitor-health/05-add-probe-gateway.md
+++ b/scenarios-3.9/monitor-health/05-add-probe-gateway.md
@@ -1,0 +1,11 @@
+You are an expert in health probes by now! Add liveness and readiness probes to the API Gateway service:
+
+```
+oc set probe dc/gateway \
+    --liveness \
+    --readiness \
+    --get-url=http://:8080/health
+```{{execute}}
+
+OpenShift automatically restarts the Inventory pod and as soon as the health probes succeed, it is 
+ready to receive traffic. 

--- a/scenarios-3.9/monitor-health/06-add-probe-web.md
+++ b/scenarios-3.9/monitor-health/06-add-probe-web.md
@@ -1,0 +1,35 @@
+Although you can add the liveness and health probes to the Web UI using a single CLI command, let's 
+give the OpenShift Web Console a try this time.
+
+Go the OpenShift Web Console by clicking on **Dashboard** and go in the **coolstore** project. Click on 
+**Applications &rarr; Deployments** on the left-side bar. Click on **web** and then the **Configuration** 
+tab. You will see the warning about health checks, with a link to
+click in order to add them. Click **Add health checks** now. 
+
+![Health Probes](https://katacoda.com/openshift-roadshow/assets/health-web-details.png)
+
+You should click on both **Add Readiness Probe** and **Add Liveness Probe** and
+then fill them out as follows:
+
+*Readiness Probe*
+
+* Path: **/**
+* Initial Delay: **10**
+* Timeout: **1**
+
+*Liveness Probe*
+
+* Path: **/**
+* Initial Delay: **180**
+* Timeout: **1**
+
+![Readiness Probe](https://katacoda.com/openshift-roadshow/assets/health-readiness.png)
+
+![Readiness Probe](https://katacoda.com/openshift-roadshow/assets/health-liveness.png)
+
+Click **Save** and then click the **Overview** button in the left navigation. You
+will notice that Web UI pod is getting restarted and it stays light blue
+for a while. This is a sign that the pod(s) have not yet passed their readiness
+checks and it turns blue when it's ready!
+
+![Web Redeploy](https://katacoda.com/openshift-roadshow/assets/health-web-redeploy.png)

--- a/scenarios-3.9/monitor-health/07-explore-metrics.md
+++ b/scenarios-3.9/monitor-health/07-explore-metrics.md
@@ -1,0 +1,15 @@
+Metrics are another important aspect of monitoring applications which is required in order to 
+gain visibility into how the application behaves and particularly in identifying issues.
+
+OpenShift provides container metrics out-of-the-box and displays how much memory, cpu and network 
+each container has been consuming over time. In the project overview, you can see three charts 
+near each pod that shows the resource consumption by that pod.
+
+![Container Metrics](https://katacoda.com/openshift-roadshow/assets/health-metrics-brief.png)
+
+Click on any of the pods (blue circle) which takes you to the pod details. Click on the **Metrics** tab 
+to see a more detailed view of the metrics charts.
+
+![Container Metrics](https://katacoda.com/openshift-roadshow/assets/health-metrics-detailed.png)
+
+Well done!

--- a/scenarios-3.9/monitor-health/99-outro.md
+++ b/scenarios-3.9/monitor-health/99-outro.md
@@ -1,0 +1,2 @@
+Move on to the next scenario, **Service Resilience and Fault Tolerance** to learn 
+about building fault tolerant microservice applications.

--- a/scenarios-3.9/monitor-health/index.json
+++ b/scenarios-3.9/monitor-health/index.json
@@ -1,0 +1,59 @@
+{
+    "pathwayTitle": "OpenShift Cloud-Native Roadshow",
+    "icon": "fa-openshift",
+    "title": "Monitoring Application Health",
+    "description": "",
+    "difficulty": "intermediate",
+    "time": "10-15 minutes",
+    "details": {
+        "steps": [
+            {
+                "title": "Health Probes",
+                "text": "01-health-probes.md"
+            },
+            {
+                "title": "Explore Health Endpoints",
+                "text": "02-explore-endpoints.md"
+            },
+            {
+                "title": "Catalog Health",
+                "text": "03-add-probe-catalog.md"
+            },
+            {
+                "title": "Monitoring Inventory Health",
+                "text": "04-add-probe-inventory.md"
+            },
+            {
+                "title": "Monitoring API Gateway Health",
+                "text": "05-add-probe-gateway.md"
+            },
+            {
+                "title": "Monitoring Web UI Health",
+                "text": "06-add-probe-web.md"
+            },
+            {
+                "title": "Container Metrics",
+                "text": "07-explore-metrics.md"
+            }
+        ],
+        "intro": {
+            "courseData": "run-init.sh",
+            "text": "00-intro.md"
+        },
+        "finish": {
+            "text": "99-outro.md"
+        }
+    },
+    "environment": {
+        "uilayout": "terminal",
+        "hideintro": false,
+        "uisettings": "javascript",
+        "showdashboard": true,
+        "dashboard": "Dashboard",
+        "uimessage1": "\u001b[32mYour Interactive Bash Terminal. A safe place to learn and execute commands.\u001b[m\r\n"
+    },
+    "backend": {
+        "imageid": "openshift-roadshow",
+        "port": 8443
+    }
+}

--- a/training/redhat3-pathway.json
+++ b/training/redhat3-pathway.json
@@ -1,0 +1,66 @@
+{
+  "title": "OpenShift Cloud-Native Roadshow",
+  "description": "",
+  "courses": [
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "getting-started",
+      "id": "getting-started",
+      "title": "Getting Started with OpenShift"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-wildfly-swarm",
+      "id": "microservice-wildfly-swarm",
+      "title": "Enterprise Microservices with WildFly Swarm"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-spring-boot",
+      "id": "microservice-spring-boot",
+      "title": "Microservices with Spring Boot"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-vertx",
+      "id": "microservice-vertx",
+      "title": "Reactive Microservices with Eclipse Vert.x"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-nodejs",
+      "id": "microservice-nodejs",
+      "title": "Web UI with Node.js and AngularJS"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "monitor-health",
+      "id": "monitor-health",
+      "title": "Monitoring Application Health"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "fault-tolerance",
+      "id": "fault-tolerance",
+      "title": "Service Resilience and Fault Tolerance"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "manage-config",
+      "id": "manage-config",
+      "title": "Managing Application Configuration"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "continuous-delivery",
+      "id": "continuous-delivery",
+      "title": "Continuous Delivery"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "debug-app",
+      "id": "debug-app",
+      "title": "Debugging Applications"
+    }
+  ]
+}

--- a/training/redhat4-pathway.json
+++ b/training/redhat4-pathway.json
@@ -1,0 +1,66 @@
+{
+  "title": "OpenShift Cloud-Native Roadshow",
+  "description": "",
+  "courses": [
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "getting-started",
+      "id": "getting-started",
+      "title": "Getting Started with OpenShift"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-wildfly-swarm",
+      "id": "microservice-wildfly-swarm",
+      "title": "Enterprise Microservices with WildFly Swarm"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-spring-boot",
+      "id": "microservice-spring-boot",
+      "title": "Microservices with Spring Boot"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-vertx",
+      "id": "microservice-vertx",
+      "title": "Reactive Microservices with Eclipse Vert.x"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-nodejs",
+      "id": "microservice-nodejs",
+      "title": "Web UI with Node.js and AngularJS"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "monitor-health",
+      "id": "monitor-health",
+      "title": "Monitoring Application Health"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "fault-tolerance",
+      "id": "fault-tolerance",
+      "title": "Service Resilience and Fault Tolerance"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "manage-config",
+      "id": "manage-config",
+      "title": "Managing Application Configuration"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "continuous-delivery",
+      "id": "continuous-delivery",
+      "title": "Continuous Delivery"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "debug-app",
+      "id": "debug-app",
+      "title": "Debugging Applications"
+    }
+  ]
+}

--- a/training/redhat5-pathway.json
+++ b/training/redhat5-pathway.json
@@ -1,0 +1,66 @@
+{
+  "title": "OpenShift Cloud-Native Roadshow",
+  "description": "",
+  "courses": [
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "getting-started",
+      "id": "getting-started",
+      "title": "Getting Started with OpenShift"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-wildfly-swarm",
+      "id": "microservice-wildfly-swarm",
+      "title": "Enterprise Microservices with WildFly Swarm"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-spring-boot",
+      "id": "microservice-spring-boot",
+      "title": "Microservices with Spring Boot"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-vertx",
+      "id": "microservice-vertx",
+      "title": "Reactive Microservices with Eclipse Vert.x"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "microservice-nodejs",
+      "id": "microservice-nodejs",
+      "title": "Web UI with Node.js and AngularJS"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "monitor-health",
+      "id": "monitor-health",
+      "title": "Monitoring Application Health"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "fault-tolerance",
+      "id": "fault-tolerance",
+      "title": "Service Resilience and Fault Tolerance"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "manage-config",
+      "id": "manage-config",
+      "title": "Managing Application Configuration"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "continuous-delivery",
+      "id": "continuous-delivery",
+      "title": "Continuous Delivery"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios",
+      "course_id": "debug-app",
+      "id": "debug-app",
+      "title": "Debugging Applications"
+    }
+  ]
+}

--- a/training/test39-pathway.json
+++ b/training/test39-pathway.json
@@ -1,0 +1,66 @@
+{
+  "title": "OpenShift Cloud-Native Roadshow",
+  "description": "",
+  "courses": [
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "getting-started",
+      "id": "getting-started",
+      "title": "Getting Started with OpenShift"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "microservice-wildfly-swarm",
+      "id": "microservice-wildfly-swarm",
+      "title": "Enterprise Microservices with WildFly Swarm"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "microservice-spring-boot",
+      "id": "microservice-spring-boot",
+      "title": "Microservices with Spring Boot"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "microservice-vertx",
+      "id": "microservice-vertx",
+      "title": "Reactive Microservices with Eclipse Vert.x"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "microservice-nodejs",
+      "id": "microservice-nodejs",
+      "title": "Web UI with Node.js and AngularJS"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "monitor-health",
+      "id": "monitor-health",
+      "title": "Monitoring Application Health"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "fault-tolerance",
+      "id": "fault-tolerance",
+      "title": "Service Resilience and Fault Tolerance"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "manage-config",
+      "id": "manage-config",
+      "title": "Managing Application Configuration"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "continuous-delivery",
+      "id": "continuous-delivery",
+      "title": "Continuous Delivery"
+    },
+    {
+      "pathway_id": "openshift-roadshow/scenarios-3.9",
+      "course_id": "debug-app",
+      "id": "debug-app",
+      "title": "Debugging Applications"
+    }
+  ]
+}


### PR DESCRIPTION
Based on master... 

* Copy/pasted 3.9 scenarios (I couldn't think of a Git-based way to do this) into own folder. 

* Add a scenario pathway so they can be processed. 

* Add a training pathway for testing.

Hope this makes it clear how the different versions and sit side-by-side for testing/updates without affecting existing training scenarios. 